### PR TITLE
Add repo integrity fetchers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+
+- [NEW] Add Github repository metadata fetcher.
+- [NEW] Add Github repository recent commits fetcher.
+- [NEW] Add Github repository branch protection fetcher.
+
 # 0.3.0
 
 - [BREAKING] Move `auditree` fetchers and checks up to arboretum.auditree.

--- a/arboretum/auditree/README.md
+++ b/arboretum/auditree/README.md
@@ -27,13 +27,13 @@ locker.
 evidence locker.  If the optional `threshold` configuration setting is applied
 then abandoned evidence is identified as evidence that has not been updated in
 over that `threshold` value otherwise the default is 30 days.  TTL is set to 1 day.
-* Expected configuration elements:
-   * org.auditree.abandoned\_evidence.threshold
+* Configuration elements:
+   * `org.auditree.abandoned_evidence.threshold`
       * Optional
       * Integer
       * Provide value in seconds
-      * Use if looking to override the default of 30 days otherwise do not include.
-   * org.auditree.abandoned\_evidence.exceptions
+      * Use if looking to override the default of 30 days.  Otherwise do not include.
+   * `org.auditree.abandoned_evidence.exceptions`
       * Optional
       * Dictionary where the key/value pairs are the path to the evidence (key)
       and the reason for excluding it from the abandoned evidence list (value).
@@ -41,7 +41,7 @@ over that `threshold` value otherwise the default is 30 days.  TTL is set to 1 d
       * Use if looking to exclude evidence files from being deemed abandoned and
       included as failures.  All "exceptions" will still appear on the report and
       will be treated as warnings rather than failures.
-* Expected configuration (optional):
+* Example (optional) configuration:
 
    ```json
    {
@@ -58,13 +58,13 @@ over that `threshold` value otherwise the default is 30 days.  TTL is set to 1 d
      }
    }
    ```
-* Expected credentials:
-   * None
+
 * Import statement:
 
    ```python
    from arboretum.auditree.fetchers.fetch_abandoned_evidence import AbandonedEvidenceFetcher
    ```
+
 ### Compliance Configuration
 
 * Class: [ComplianceConfigFetcher][fetch-compliance-config]
@@ -74,16 +74,208 @@ to the evidence locker.
 the evidence locker and sets a time to live (TTL) to 2 hours.  This fetcher
 ignores TTL and will refresh the configuration evidence on every execution of
 the fetchers.
-* Expected configuration elements:
-   * None
-* Expected configuration:
-   * None
-* Expected credentials:
-   * None
 * Import statement:
 
    ```python
    from arboretum.auditree.fetchers.fetch_compliance_config import ComplianceConfigFetcher
+   ```
+
+### Repository Integrity (Metadata)
+
+* Class: [GithubRepoMetaDataFetcher][fetch-repo-metadata]
+* Purpose: Writes Github repository metadata details evidence to the evidence
+locker.  This fetcher class is only meant for use with Github or Github
+Enterprise repositories.
+* Behavior: For each Github repository specified, an evidence file is stored in
+the locker containing that repository's metadata details.  If no repositories
+are specified the fetcher defaults to retrieving the evidence locker repository
+metadata detail.  TTL is set to 1 day.
+* Configuration elements:
+   * `org.auditree.repo_integrity.repos`
+      * Optional
+      * List of Github repository URLs (string).
+      * Use if looking to specify multiple repos or to override the evidence
+      locker repo default.  Otherwise do not include.
+* Example (optional) configuration:
+
+   ```json
+   {
+     "org": {
+       "auditree": {
+         "repo_integrity": {
+           "repos": [
+             "https://github.com/org-foo/repo-foo",
+             "https://github.com/org-bar/repo-bar"
+           ]
+         }
+       }
+     }
+   }
+   ```
+
+* Required credentials:
+   * `github` or `github_enterprise` credentials with admin permissions to the
+   repository are required for this fetcher to successfully retrieve evidence.
+      * `username`: The Github user used to run the fetcher.
+      * `token`: The Github user access token used to run the fetcher.
+   * Example credentials file entry:
+
+      ```ini
+      [github]
+      username=gh-user-name
+      token=gh-access-token
+      ```
+
+      or
+
+      ```ini
+      [github_enterprise]
+      username=ghe-user-name
+      token=ghe-access-token
+      ```
+
+   * NOTE: These credentials are also needed for basic configuration of the
+   Auditree framework.  The expectation is that the same credentials are used
+   for all Github interactions.
+
+* Import statement:
+
+   ```python
+   from arboretum.auditree.fetchers.github.fetch_repo_metadata import GithubRepoMetaDataFetcher
+   ```
+
+### Repository Integrity (Recent Commits)
+
+* Class: [GithubRepoCommitsFetcher][fetch-recent-commits]
+* Purpose: Writes the most recent Github repository branch commit details
+to the evidence locker.  This fetcher class is only meant for use with Github
+or Github Enterprise repositories.
+* Behavior: For each Github repository and branch specified, an evidence file
+is stored in the locker containing that repository branch's most recent (last 2
+days) commit details.  If no repositories are specified the fetcher defaults to
+retrieving the evidence locker `master` branch commit detail.  TTL is set to 1
+day.
+* Configuration elements:
+   * `org.auditree.repo_integrity.branches`
+      * Optional
+      * Dictionary:
+         * Key: Github repository URL (string)
+         * Value: List of branches (string) for that repository.
+      * Use if looking to specify multiple repos/branches or to override the
+      evidence locker repo and `master` branch default.  Otherwise do not include.
+* Example (optional) configuration:
+
+   ```json
+   {
+     "org": {
+       "auditree": {
+         "repo_integrity": {
+           "branches": {
+             "https://github.com/org-foo/repo-foo": ["main", "develop"],
+             "https://github.com/org-bar/repo-bar": ["main"]
+           }
+         }
+       }
+     }
+   }
+   ```
+
+* Required credentials:
+   * `github` or `github_enterprise` credentials with admin permissions to the
+   repository are required for this fetcher to successfully retrieve evidence.
+      * `username`: The Github user used to run the fetcher.
+      * `token`: The Github user access token used to run the fetcher.
+   * Example credentials file entry:
+
+      ```ini
+      [github]
+      username=gh-user-name
+      token=gh-access-token
+      ```
+
+      or
+
+      ```ini
+      [github_enterprise]
+      username=ghe-user-name
+      token=ghe-access-token
+      ```
+
+   * NOTE: These credentials are also needed for basic configuration of the
+   Auditree framework.  The expectation is that the same credentials are used
+   for all Github interactions.
+
+* Import statement:
+
+   ```python
+   from arboretum.auditree.fetchers.github.fetch_recent_commits import GithubRepoCommitsFetcher
+   ```
+
+### Repository Integrity (Branch Protection)
+
+* Class: [GithubRepoBranchProtectionFetcher][fetch-branch-protection]
+* Purpose: Writes the Github repository branch protection details to the
+evidence locker.  This fetcher class is only meant for use with Github or
+Github Enterprise repositories.
+* Behavior: For each Github repository and branch specified, an evidence file
+is stored in the locker containing that repository branch's branch protection
+details.  If no repositories are specified the fetcher defaults to retrieving
+the evidence locker `master` branch branch protection detail.  TTL is set to 1
+day.
+* Configuration elements:
+   * `org.auditree.repo_integrity.branches`
+      * Optional
+      * Dictionary:
+         * Key: Github repository URL (string)
+         * Value: List of branches (string) for that repository.
+      * Use if looking to specify multiple repos/branches or to override the
+      evidence locker repo and `master` branch default.  Otherwise do not include.
+* Example (optional) configuration:
+
+   ```json
+   {
+     "org": {
+       "auditree": {
+         "repo_integrity": {
+           "branches": {
+             "https://github.com/org-foo/repo-foo": ["main", "develop"],
+             "https://github.com/org-bar/repo-bar": ["main"]
+           }
+         }
+       }
+     }
+   }
+   ```
+
+* Required credentials:
+   * `github` or `github_enterprise` credentials with admin permissions to the
+   repository are required for this fetcher to successfully retrieve evidence.
+      * `username`: The Github user used to run the fetcher.
+      * `token`: The Github user access token used to run the fetcher.
+   * Example credentials file entry:
+
+      ```ini
+      [github]
+      username=gh-user-name
+      token=gh-access-token
+      ```
+
+      or
+
+      ```ini
+      [github_enterprise]
+      username=ghe-user-name
+      token=ghe-access-token
+      ```
+
+   * NOTE: These credentials are also needed for basic configuration of the
+   Auditree framework.  The expectation is that the same credentials are used
+   for all Github interactions.
+
+* Import statement:
+
+   ```python
+   from arboretum.auditree.fetchers.github.fetch_branch_protection import GithubRepoBranchProtectionFetcher
    ```
 
 ### Python Packages
@@ -94,12 +286,6 @@ the fetchers.
 the latest release information for `auditree-arboretum`, `auditree-framework`
 and `auditree-harvest` are also retrieved and stored as evidence.  The time to
 live (TTL) is set to 1 day for all evidences.
-* Expected configuration elements:
-   * None
-* Expected configuration:
-   * None
-* Expected credentials:
-   * None
 * Import statement:
 
    ```python
@@ -128,13 +314,13 @@ execution.  The default threshold is 30 days beyond the time to live (TTL) setti
    store "abandoned evidence" evidence in the locker then the tooling performs
    a sweep of the evidence locker metadata to assess evidence that has not been
    updated in the timeframe specified.
-* Expected configuration elements:
-   * org.auditree.abandoned\_evidence.threshold
+* Configuration elements:
+   * `org.auditree.abandoned_evidence.threshold`
       * Optional
       * Integer
       * Provide value in seconds
-      * Use if looking to override the default of 30 days otherwise do not include.
-   * org.auditree.abandoned\_evidence.exceptions
+      * Use if looking to override the default of 30 days.  Otherwise do not include.
+   * `org.auditree.abandoned_evidence.exceptions`
       * Optional
       * Dictionary where the key/value pairs are the path to the evidence (key)
       and the reason for excluding it from the abandoned evidence list (value).
@@ -142,14 +328,14 @@ execution.  The default threshold is 30 days beyond the time to live (TTL) setti
       * Use if looking to exclude evidence files from being deemed abandoned
       and included as failures.  All "exceptions" will still appear on the
       report and will be treated as warnings rather than failures.
-   * org.auditree.abandoned\_evidence.ignore\_history
+   * `org.auditree.abandoned_evidence.ignore_history`
       * Optional
       * Boolean
       * Set to `true`
       * Use if collecting `raw/auditree/abandoned_evidence.json` in the evidence
       locker but intend to run the check without referencing the evidence history
       (more rigid alerts).  Otherwise do not include.
-* Expected configuration (optional):
+* Example (optional) configuration:
 
    ```json
    {
@@ -173,6 +359,7 @@ execution.  The default threshold is 30 days beyond the time to live (TTL) setti
    ```python
    from arboretum.auditree.checks.test_abandoned_evidence import AbandonedEvidenceCheck
    ```
+
 ### Compliance Configuration
 
 * Class: [ComplianceConfigCheck][check-compliance-config]
@@ -184,11 +371,6 @@ configuration a failure is generated and reported on.
    * Compliance tooling configuration settings
       * `raw/auditree/compliance_config.json`
       * Gathered by the `auditree` provider [ComplianceConfigFetcher][fetch-compliance-config]
-* Expected configuration elements:
-   * None
-* Expected configuration (optional):
-   * None
-
 * Import statement:
 
    ```python
@@ -213,11 +395,6 @@ used are not at the current release version.
       * `raw/auditree/auditree_framework_releases.xml`
       * `raw/auditree/auditree_harvest_releases.xml`
       * Gathered by the `technology.auditree` [PythonPackageFetcher][fetch-python-packages]
-* Expected configuration elements:
-   * None
-* Expected configuration (optional):
-   * None
-
 * Import statement:
 
    ```python
@@ -228,6 +405,9 @@ used are not at the current release version.
 [fetch-abandoned-evidence]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/fetch_abandoned_evidence.py
 [fetch-compliance-config]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/fetch_compliance_config.py
 [fetch-python-packages]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/fetch_python_packages.py
+[fetch-repo-metadata]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/github/fetch_repo_metadata.py
+[fetch-recent-commits]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/github/fetch_recent_commits.py
+[fetch-branch-protection]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/github/fetch_branch_protection.py
 [check-abandoned-evidence]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/checks/test_abandoned_evidence.py
 [check-compliance-config]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/checks/test_compliance_config.py
 [check-python-packages]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/checks/test_python_packages.py

--- a/arboretum/auditree/fetchers/github/__init__.py
+++ b/arboretum/auditree/fetchers/github/__init__.py
@@ -1,0 +1,15 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Auditree Github evidence gathering fetchers."""

--- a/arboretum/auditree/fetchers/github/fetch_branch_protection.py
+++ b/arboretum/auditree/fetchers/github/fetch_branch_protection.py
@@ -1,0 +1,73 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Github repository branch protection fetcher."""
+
+import json
+import os
+from urllib.parse import urlparse
+
+from compliance.evidence import DAY, RawEvidence, raw_evidence
+from compliance.fetch import ComplianceFetcher
+from compliance.utils.services.github import Github
+
+
+class GithubRepoBranchProtectionFetcher(ComplianceFetcher):
+    """Fetch Github repository branch protection metadata."""
+
+    def fetch_gh_repo_branch_protection_details(self):
+        """Fetch Github repository branch protection metadata."""
+        branches = self.config.get(
+            'org.auditree.repo_integrity.branches',
+            {self.config.get('locker.repo_url'): ['master']}
+        )
+        current_url = None
+        github = None
+        for repo_url, repo_branches in branches.items():
+            parsed = urlparse(repo_url)
+            base_url = f'{parsed.scheme}://{parsed.hostname}'
+            repo = parsed.path.strip('/')
+            for branch in repo_branches:
+                file_prefix_parts = [
+                    repo.lower().replace('/', '_').replace('-', '_'),
+                    branch.lower().replace('-', '_')
+                ]
+                file_prefix = '_'.join(file_prefix_parts)
+                path = ['auditree', f'gh_{file_prefix}_branch_protection.json']
+                if base_url != current_url:
+                    github = Github(self.config.creds, base_url)
+                    current_url = base_url
+                self.config.add_evidences(
+                    [
+                        RawEvidence(
+                            path[1],
+                            path[0],
+                            DAY,
+                            (
+                                f'Github branch protection for {repo} repo '
+                                f'{branch} branch'
+                            )
+                        )
+                    ]
+                )
+                joined_path = os.path.join(*path)
+                with raw_evidence(self.locker, joined_path) as evidence:
+                    if evidence:
+                        evidence.set_content(
+                            json.dumps(
+                                github.get_branch_protection_details(
+                                    repo, branch
+                                )
+                            )
+                        )

--- a/arboretum/auditree/fetchers/github/fetch_recent_commits.py
+++ b/arboretum/auditree/fetchers/github/fetch_recent_commits.py
@@ -1,0 +1,76 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Github repository branch recent commits fetcher."""
+
+import json
+import os
+from datetime import datetime, timedelta
+from urllib.parse import urlparse
+
+from compliance.evidence import DAY, RawEvidence, raw_evidence
+from compliance.fetch import ComplianceFetcher
+from compliance.utils.services.github import Github
+
+
+class GithubRepoCommitsFetcher(ComplianceFetcher):
+    """Fetch Github repository branch recent commits metadata."""
+
+    def fetch_gh_repo_branch_recent_commits_details(self):
+        """Fetch Github repository branch recent commits metadata."""
+        branches = self.config.get(
+            'org.auditree.repo_integrity.branches',
+            {self.config.get('locker.repo_url'): ['master']}
+        )
+        current_url = None
+        github = None
+        for repo_url, repo_branches in branches.items():
+            parsed = urlparse(repo_url)
+            base_url = f'{parsed.scheme}://{parsed.hostname}'
+            repo = parsed.path.strip('/')
+            for branch in repo_branches:
+                file_prefix_parts = [
+                    repo.lower().replace('/', '_').replace('-', '_'),
+                    branch.lower().replace('-', '_')
+                ]
+                file_prefix = '_'.join(file_prefix_parts)
+                path = ['auditree', f'gh_{file_prefix}_recent_commits.json']
+                if base_url != current_url:
+                    github = Github(self.config.creds, base_url)
+                    current_url = base_url
+                self.config.add_evidences(
+                    [
+                        RawEvidence(
+                            path[1],
+                            path[0],
+                            DAY,
+                            (
+                                f'Github recent commits for {repo} repo '
+                                f'{branch} branch'
+                            )
+                        )
+                    ]
+                )
+                joined_path = os.path.join(*path)
+                with raw_evidence(self.locker, joined_path) as evidence:
+                    if evidence:
+                        period = evidence.ttl * 2
+                        if period < DAY:
+                            period = DAY
+                        since = datetime.utcnow() - timedelta(seconds=period)
+                        evidence.set_content(
+                            json.dumps(
+                                github.get_commit_details(repo, since, branch)
+                            )
+                        )

--- a/arboretum/auditree/fetchers/github/fetch_repo_metadata.py
+++ b/arboretum/auditree/fetchers/github/fetch_repo_metadata.py
@@ -1,0 +1,60 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Github repository metadata fetcher."""
+
+import json
+import os
+from urllib.parse import urlparse
+
+from compliance.evidence import DAY, RawEvidence, raw_evidence
+from compliance.fetch import ComplianceFetcher
+from compliance.utils.services.github import Github
+
+
+class GithubRepoMetaDataFetcher(ComplianceFetcher):
+    """Fetch Github repository metadata."""
+
+    def fetch_gh_repo_details(self):
+        """Fetch Github repository metadata."""
+        repo_urls = self.config.get(
+            'org.auditree.repo_integrity.repos',
+            [self.config.get('locker.repo_url')]
+        )
+        current_url = None
+        github = None
+        for repo_url in repo_urls:
+            parsed = urlparse(repo_url)
+            base_url = f'{parsed.scheme}://{parsed.hostname}'
+            repo = parsed.path.strip('/')
+            file_prefix = repo.lower().replace('/', '_').replace('-', '_')
+            path = ['auditree', f'gh_{file_prefix}_repo_metadata.json']
+            if base_url != current_url:
+                github = Github(self.config.creds, base_url)
+                current_url = base_url
+            self.config.add_evidences(
+                [
+                    RawEvidence(
+                        path[1],
+                        path[0],
+                        DAY,
+                        f'Github {repo} repo metadata details'
+                    )
+                ]
+            )
+            with raw_evidence(self.locker, os.path.join(*path)) as evidence:
+                if evidence:
+                    evidence.set_content(
+                        json.dumps(github.get_repo_details(repo))
+                    )


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add repo integrity fetchers

## Why

These fetchers will serve as the fetching mechanism for Github evidence locker integrity checks as well as other Github repository integrity checks.

## How

- Add repo metadata fetcher
- Add repo/branch recent commits fetcher
- Add repo/branch branch protection fetcher

## Test

- Fetchers tested in dev environment created separate evidence files for each repo and repo/branch combo.

## Context

In support of #13 
