### PR TITLE
Add GH repo branch filepath commits fetcher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+
+- [NEW] Add Github repository file/folder recent commits fetcher.
+- [IMPROVED] Github repository recent commits fetcher now fetches since evidence last update.
+- [CHANGED] Evidence fetched by Github repository recent commits fetcher, TTL now set to 2 days.
+
 # 0.4.0
 
 - [NEW] Add Github repository metadata fetcher.

--- a/arboretum/auditree/README.md
+++ b/arboretum/auditree/README.md
@@ -114,7 +114,7 @@ metadata detail.  TTL is set to 1 day.
    ```
 
 * Required credentials:
-   * `github` or `github_enterprise` credentials with admin permissions to the
+   * `github` or `github_enterprise` credentials with read permissions to the
    repository are required for this fetcher to successfully retrieve evidence.
       * `username`: The Github user used to run the fetcher.
       * `token`: The Github user access token used to run the fetcher.
@@ -151,10 +151,10 @@ metadata detail.  TTL is set to 1 day.
 to the evidence locker.  This fetcher class is only meant for use with Github
 or Github Enterprise repositories.
 * Behavior: For each Github repository and branch specified, an evidence file
-is stored in the locker containing that repository branch's most recent (last 2
-days) commit details.  If no repositories are specified the fetcher defaults to
-retrieving the evidence locker `master` branch commit detail.  TTL is set to 1
-day.
+is stored in the locker containing that repository branch's most recent (since
+the last time the evidence was fetched) commit details.  If no repositories
+are specified the fetcher defaults to retrieving the evidence locker `master`
+branch commit detail.  TTL is set to 2 days.
 * Configuration elements:
    * `org.auditree.repo_integrity.branches`
       * Optional
@@ -181,7 +181,7 @@ day.
    ```
 
 * Required credentials:
-   * `github` or `github_enterprise` credentials with admin permissions to the
+   * `github` or `github_enterprise` credentials with read permissions to the
    repository are required for this fetcher to successfully retrieve evidence.
       * `username`: The Github user used to run the fetcher.
       * `token`: The Github user access token used to run the fetcher.
@@ -209,6 +209,78 @@ day.
 
    ```python
    from arboretum.auditree.fetchers.github.fetch_recent_commits import GithubRepoCommitsFetcher
+   ```
+
+### Repository Integrity (Recent File Path Commits)
+
+* Class: [GithubFilePathCommitsFetcher][fetch-filepath-commits]
+* Purpose: Writes the most recent Github repository branch file path commit
+details to the evidence locker.  This fetcher class is only meant for use with
+Github or Github Enterprise repositories.
+* Behavior: For each Github repository, branch and file path specified, an
+evidence file is stored in the locker containing that repository branch file
+path's most recent (since the last time the evidence was collected) commit
+details.  A file path can be a relative path to a file or a folder within the
+repository.  TTL is set to 1 day.
+* Configuration elements:
+   * `org.auditree.repo_integrity.filepaths`
+      * Required
+      * Dictionary:
+         * Key: Github repository URL (string)
+         * Value: Dictionary of branches and file paths within the branch.
+            * Key: Branch name (string)
+            * Value: List of file paths (string) for that repository/branch.
+* Example (required) configuration:
+
+   ```json
+   {
+     "org": {
+       "auditree": {
+         "repo_integrity": {
+           "filepaths": {
+             "https://github.com/org-foo/repo-foo": {
+               "main": ["foo", "bar/baz.json"],
+               "develop": ["README.md"]
+             },
+             "https://github.com/org-bar/repo-bar": {
+               "main": ["README.md", "foo/bar/baz.py"]
+             }
+           }
+         }
+       }
+     }
+   }
+   ```
+
+* Required credentials:
+   * `github` or `github_enterprise` credentials with read permissions to the
+   repository are required for this fetcher to successfully retrieve evidence.
+      * `username`: The Github user used to run the fetcher.
+      * `token`: The Github user access token used to run the fetcher.
+   * Example credentials file entry:
+
+      ```ini
+      [github]
+      username=gh-user-name
+      token=gh-access-token
+      ```
+
+      or
+
+      ```ini
+      [github_enterprise]
+      username=ghe-user-name
+      token=ghe-access-token
+      ```
+
+   * NOTE: These credentials are also needed for basic configuration of the
+   Auditree framework.  The expectation is that the same credentials are used
+   for all Github interactions.
+
+* Import statement:
+
+   ```python
+   from arboretum.auditree.fetchers.github.fetch_filepath_commits import GithubFilePathCommitsFetcher
    ```
 
 ### Repository Integrity (Branch Protection)
@@ -523,6 +595,7 @@ the current evidence locker URL.
 [fetch-python-packages]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/fetch_python_packages.py
 [fetch-repo-metadata]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/github/fetch_repo_metadata.py
 [fetch-recent-commits]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/github/fetch_recent_commits.py
+[fetch-filepath-commits]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/github/fetch_filepath_commits.py
 [fetch-branch-protection]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/fetchers/github/fetch_branch_protection.py
 [check-abandoned-evidence]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/checks/test_abandoned_evidence.py
 [check-compliance-config]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/auditree/checks/test_compliance_config.py

--- a/arboretum/auditree/fetchers/github/fetch_filepath_commits.py
+++ b/arboretum/auditree/fetchers/github/fetch_filepath_commits.py
@@ -1,0 +1,86 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Github repository branch file path recent commits fetcher."""
+
+import json
+import os
+from datetime import datetime
+from urllib.parse import urlparse
+
+from arboretum.auditree.evidences.repo_commit import RepoCommitEvidence
+from arboretum.common.constants import LOCKER_DTTM_FORMAT
+
+from compliance.evidence import DAY, raw_evidence
+from compliance.fetch import ComplianceFetcher
+from compliance.utils.services.github import Github
+
+
+class GithubFilePathCommitsFetcher(ComplianceFetcher):
+    """Fetch Github repository branch file path recent commits metadata."""
+
+    def fetch_gh_repo_branch_file_path_recent_commits_details(self):
+        """Fetch Github repository branch file path recent commits metadata."""
+        filepaths = self.config.get('org.auditree.repo_integrity.filepaths')
+        current_url = None
+        github = None
+        for repo_url, repo_branches in filepaths.items():
+            parsed = urlparse(repo_url)
+            base_url = f'{parsed.scheme}://{parsed.hostname}'
+            repo = parsed.path.strip('/')
+            for branch, repo_filepaths in repo_branches.items():
+                for filepath in repo_filepaths:
+                    ev_file_prefix = f'{repo}_{branch}_{filepath}'.lower()
+                    for symbol in [' ', '/', '-', '.']:
+                        ev_file_prefix = ev_file_prefix.replace(symbol, '_')
+                    path = [
+                        'auditree', f'gh_{ev_file_prefix}_recent_commits.json'
+                    ]
+                    if base_url != current_url:
+                        github = Github(self.config.creds, base_url)
+                        current_url = base_url
+                    self.config.add_evidences(
+                        [
+                            RepoCommitEvidence(
+                                path[1],
+                                path[0],
+                                DAY,
+                                (
+                                    f'Github recent commits for {repo} repo '
+                                    f'{branch} branch, {filepath} file path'
+                                )
+                            )
+                        ]
+                    )
+                    joined_path = os.path.join(*path)
+                    with raw_evidence(self.locker, joined_path) as evidence:
+                        if evidence:
+                            meta = self.locker.get_evidence_metadata(
+                                evidence.path
+                            )
+                            if meta is None:
+                                meta = {}
+                            utcnow = datetime.utcnow()
+                            now = utcnow.strftime(LOCKER_DTTM_FORMAT)
+                            since = datetime.strptime(
+                                meta.get('last_update', now),
+                                LOCKER_DTTM_FORMAT
+                            )
+                            evidence.set_content(
+                                json.dumps(
+                                    github.get_commit_details(
+                                        repo, since, branch, filepath
+                                    )
+                                )
+                            )

--- a/arboretum/common/constants.py
+++ b/arboretum/common/constants.py
@@ -32,3 +32,6 @@ IGNORE_REPO_METADATA = {
         'temp_clone_token'
     ]
 }
+
+# Evidence locker metadata datetime format
+LOCKER_DTTM_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'

--- a/devel.json
+++ b/devel.json
@@ -9,15 +9,14 @@
     "slack": {}
   },
   "org": {
-    "name": "Auditree",
+    "name": "MY-ORG",
     "auditree": {
-      "abandoned_evidence": {
-        "threshold": 604800,
-        "exceptions": {
-          "raw/foo/bar.json":
-          "Evidence moved to a new location in locker but this is historical evidence we want to keep."
-        },
-        "ignore_history": true
+      "repo_integrity": {
+        "filepaths": {
+          "https://github.com/ComplianceAsCode/auditree-arboretum": {
+            "main": ["arboretum/common/constants.py"]
+          }
+        }
       }
     }
   }

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ long_description = file: README.md
 include_package_data = True
 packages = find:
 install_requires =
-    auditree-framework>=1.2.2
+    auditree-framework>=1.2.3
     auditree-harvest>=1.0.0
 
 [options.packages.find]


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Add GH repo branch file path recent commits fetcher.
- Update GH repo branch recent commits fetcher to fetch based on evidence `last_update`.
- Set TTL for evidence gathered by GH repo branch recent commits fetcher to 2 days.

## Why

- The file path fetcher will allow us to write checks that verify whether individual files or folders were touched unexpectedly with a Github repo.
- Changing the TTL and basing the fetch process off of the `last_update` for the GH repo branch recent commits fetcher is a more dynamic way to gathering the evidence and will ensure that if a lapse in time between executions occurs, the evidence collected will "catch up" based on `last_update`.

## How

- Added a new GH repo branch file path recent commits fetcher.
- Updated the GH repo branch recent commits fetcher to use last_update for the "since" date when calling the GH API.
- Updated evidence gathered by the GH repo branch recent commits fetcher to be 2 days.

## Test

- Evidence is gathered as expected by both fetchers.

## Context

In support of #18 
