### PR TITLE
Add repo integrity checks and fetcher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,11 @@
-# UNRELEASED
+# 0.5.0
 
-- [NEW] Add Github repository file/folder recent commits fetcher.
-- [IMPROVED] Github repository recent commits fetcher now fetches since evidence last update.
-- [CHANGED] Evidence fetched by Github repository recent commits fetcher, TTL now set to 2 days.
+- [NEW] Add repository/branch new commits check.
+- [NEW] Add repository/branch/filepath new commits check.
+- [NEW] Add Github repository/branch/filepath recent commits fetcher.
+- [IMPROVED] Github repository/branch recent commits fetcher now fetches since evidence last update.
+- [CHANGED] Github repo recent commits evidence: TTL set to 2 days for locker, 1 day all other repos.
+- [FIXED] Links to the `auditree-framework` in README.md files are correct now.
 
 # 0.4.0
 

--- a/arboretum/__init__.py
+++ b/arboretum/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Arboretum - Checking your compliance & security posture, continuously."""
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'

--- a/arboretum/ansible/README.md
+++ b/arboretum/ansible/README.md
@@ -4,8 +4,7 @@ The fetchers and checks contained within this `ansible` category folder are
 common tests that can be configured and executed for the purpose of generating
 compliance reports and notifications using the [auditree-framework][].  They
 validate the configuration and ensure smooth execution of an auditree instance.
-See [auditree-framework documentation](https://complianceascode.github.io/auditree-framework/)
-for more details.
+See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like
 [Travis CI](https://travis-ci.com/) as part of another project that uses this
@@ -13,8 +12,8 @@ library package as a dependency.
 
 ## Usage as a library
 
-See [usage][usage] for specifics on including this library as a dependency and
-how to include the fetchers and checks from this library in your downstream project.
+See [usage][] for specifics on including this library as a dependency and how
+to include the fetchers and checks from this library in your downstream project.
 
 ## Fetchers
 
@@ -24,4 +23,6 @@ Fetchers coming soon...
 
 Checks coming soon...
 
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
 [usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage

--- a/arboretum/auditree/checks/test_filepath_commits.py
+++ b/arboretum/auditree/checks/test_filepath_commits.py
@@ -1,0 +1,95 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repository/branch/filepath new commits check."""
+
+from urllib.parse import urlparse
+
+from arboretum.auditree.evidences.repo_commit import RepoCommitEvidence
+
+from compliance.check import ComplianceCheck
+from compliance.evidence import DAY, ReportEvidence, evidences
+
+
+class FilepathNewCommitsCheck(ComplianceCheck):
+    """Monitor repository/branch/filepath new commits."""
+
+    @property
+    def title(self):
+        """
+        Return the title of the checks.
+
+        :returns: the title of the checks
+        """
+        return 'Repository/Branch/Filepath New Commits'
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialize the check object with configuration settings."""
+        cls.config.add_evidences(
+            [
+                ReportEvidence(
+                    'filepath_new_commits.md',
+                    'auditree',
+                    DAY,
+                    'Repository/branch/filepath new commits report.'
+                )
+            ]
+        )
+        return cls
+
+    def test_new_filepath_commits(self):
+        """Check for new commits made to a repo/branch/filepath."""
+        filepaths = self.config.get('org.auditree.repo_integrity.filepaths')
+        for repo_url, repo_branches in filepaths.items():
+            parsed = urlparse(repo_url)
+            service = 'gh'
+            if 'gitlab' in parsed.hostname:
+                service = 'gl'
+            elif 'bitbucket' in parsed.hostname:
+                service = 'bb'
+            repo = parsed.path.strip('/')
+            for repo_branch, repo_filepaths in repo_branches.items():
+                for filepath in repo_filepaths:
+                    ev_file_prefix = f'{repo}_{repo_branch}_{filepath}'.lower()
+                    for symbol in [' ', '/', '-', '.']:
+                        ev_file_prefix = ev_file_prefix.replace(symbol, '_')
+                    fname = f'{service}_{ev_file_prefix}_recent_commits.json'
+                    with evidences(self, f'raw/auditree/{fname}') as raw:
+                        commits = RepoCommitEvidence.from_evidence(raw)
+                        for commit in commits.author_info:
+                            commit['repo'] = repo_url
+                            commit['branch'] = repo_branch
+                            self.add_warnings(
+                                f'Recent Commits Found - (`{filepath}`)',
+                                commit
+                            )
+
+    def get_reports(self):
+        """
+        Provide the check report name.
+
+        :returns: the report(s) generated for this check
+        """
+        return ['auditree/filepath_new_commits.md']
+
+    def get_notification_message(self):
+        """
+        Repository/branch/filepath new commits check notifier.
+
+        :returns: notification dictionary
+        """
+        return {
+            'subtitle': 'Repository/branch/filepath new commits', 'body': None
+        }

--- a/arboretum/auditree/checks/test_locker_commit_integrity.py
+++ b/arboretum/auditree/checks/test_locker_commit_integrity.py
@@ -78,8 +78,8 @@ class LockerCommitIntegrityCheck(ComplianceCheck):
                 ]
                 path = f'raw/auditree/{"_".join(filename)}'
                 with evidences(self, path) as raw:
-                    evidence = RepoCommitEvidence.from_evidence(raw)
-                    for commit in evidence.commit_signed_status:
+                    commits = RepoCommitEvidence.from_evidence(raw)
+                    for commit in commits.signed_status:
                         if not commit['signed']:
                             self.add_failures(
                                 'Locker Recent Commits - (Unsigned)',

--- a/arboretum/auditree/checks/test_repo_branch_commits.py
+++ b/arboretum/auditree/checks/test_repo_branch_commits.py
@@ -1,0 +1,96 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repository/branch new commits check."""
+
+from urllib.parse import urlparse
+
+from arboretum.auditree.evidences.repo_commit import RepoCommitEvidence
+
+from compliance.check import ComplianceCheck
+from compliance.evidence import DAY, ReportEvidence, evidences
+
+
+class RepoBranchNewCommitsCheck(ComplianceCheck):
+    """Monitor repository/branch new commits."""
+
+    @property
+    def title(self):
+        """
+        Return the title of the checks.
+
+        :returns: the title of the checks
+        """
+        return 'Repository/Branch New Commits'
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialize the check object with configuration settings."""
+        cls.config.add_evidences(
+            [
+                ReportEvidence(
+                    'repo_branch_new_commits.md',
+                    'auditree',
+                    DAY,
+                    'Repository/branch new commits report.'
+                )
+            ]
+        )
+        return cls
+
+    def test_new_repo_branch_commits(self):
+        """Check for new commits made to a repo/branch."""
+        branches = self.config.get('org.auditree.repo_integrity.branches')
+        for repo_url, repo_branches in branches.items():
+            parsed = urlparse(repo_url)
+            service = 'gh'
+            if 'gitlab' in parsed.hostname:
+                service = 'gl'
+            elif 'bitbucket' in parsed.hostname:
+                service = 'bb'
+            repo = parsed.path.strip('/')
+            for repo_branch in repo_branches:
+                # If included, skip check on the evidence locker
+                if (repo_url == self.locker.repo_url
+                        and repo_branch == self.locker.branch):
+                    continue
+                filename = [
+                    service,
+                    repo.lower().replace('/', '_').replace('-', '_'),
+                    repo_branch.lower().replace('-', '_'),
+                    'recent_commits.json'
+                ]
+                path = f'raw/auditree/{"_".join(filename)}'
+                with evidences(self, path) as raw:
+                    commits = RepoCommitEvidence.from_evidence(raw)
+                    for commit in commits.author_info:
+                        commit['repo'] = repo_url
+                        commit['branch'] = repo_branch
+                        self.add_warnings('Recent Commits Found', commit)
+
+    def get_reports(self):
+        """
+        Provide the check report name.
+
+        :returns: the report(s) generated for this check
+        """
+        return ['auditree/repo_branch_new_commits.md']
+
+    def get_notification_message(self):
+        """
+        Repository/branch new commits check notifier.
+
+        :returns: notification dictionary
+        """
+        return {'subtitle': 'Repository/branch new commits', 'body': None}

--- a/arboretum/auditree/evidences/repo_commit.py
+++ b/arboretum/auditree/evidences/repo_commit.py
@@ -23,21 +23,42 @@ class RepoCommitEvidence(RawEvidence):
     """Repository commit raw evidence class."""
 
     @property
-    def commit_signed_status(self):
+    def signed_status(self):
         """Provide verified/signed status for each commit as a list."""
         if self.content:
-            rs_factory = {
-                'gh': self._get_gh_commit_signed_status,
-                'gl': self._get_gl_commit_signed_status,
-                'bb': self._get_bb_commit_signed_status
+            ss_factory = {
+                'gh': self._get_gh_signed_status,
+                'gl': self._get_gl_signed_status,
+                'bb': self._get_bb_signed_status
             }
-            if not hasattr(self, '_commit_signed_status'):
-                self._commit_signed_status = rs_factory[self.name[:2]]()
-            return self._commit_signed_status
+            if not hasattr(self, '_signed_status'):
+                self._signed_status = ss_factory[self.name[:2]]()
+            return self._signed_status
 
-    def _get_gh_commit_signed_status(self):
+    @property
+    def author_info(self):
+        """Provide author name and date/time for each commit as a list."""
+        if self.content:
+            ai_factory = {
+                'gh': self._get_gh_author_info,
+                'gl': self._get_gl_author_info,
+                'bb': self._get_bb_author_info
+            }
+            if not hasattr(self, '_author_info'):
+                self._author_info = ai_factory[self.name[:2]]()
+            return self._author_info
+
+    @property
+    def as_a_list(self):
+        """Provide recent commits content as a list."""
+        if self.content:
+            if not hasattr(self, '_as_a_list'):
+                self._as_a_list = json.loads(self.content)
+            return self._as_a_list
+
+    def _get_gh_signed_status(self):
         commits = []
-        for commit in json.loads(self.content):
+        for commit in self.as_a_list:
             commits.append(
                 {
                     'sha': commit['sha'],
@@ -47,8 +68,27 @@ class RepoCommitEvidence(RawEvidence):
             )
         return commits
 
-    def _get_gl_commit_signed_status(self):
+    def _get_gl_signed_status(self):
         raise NotImplementedError('Support for Gitlab coming soon...')
 
-    def _get_bb_commit_signed_status(self):
+    def _get_bb_signed_status(self):
+        raise NotImplementedError('Support for Bitbucket coming soon...')
+
+    def _get_gh_author_info(self):
+        commits = []
+        for commit in self.as_a_list:
+            commits.append(
+                {
+                    'sha': commit['sha'],
+                    'url': commit['html_url'],
+                    'author': commit['commit']['author']['name'],
+                    'datetime': commit['commit']['author']['date']
+                }
+            )
+        return commits
+
+    def _get_gl_author_info(self):
+        raise NotImplementedError('Support for Gitlab coming soon...')
+
+    def _get_bb_author_info(self):
         raise NotImplementedError('Support for Bitbucket coming soon...')

--- a/arboretum/auditree/fetchers/github/fetch_recent_commits.py
+++ b/arboretum/auditree/fetchers/github/fetch_recent_commits.py
@@ -52,12 +52,17 @@ class GithubRepoCommitsFetcher(ComplianceFetcher):
                 if base_url != current_url:
                     github = Github(self.config.creds, base_url)
                     current_url = base_url
+                ttl = DAY
+                # To ensure signed commits check picks up locker commits
+                if (repo_url == self.locker.repo_url
+                        and branch == self.locker.branch):
+                    ttl = DAY * 2
                 self.config.add_evidences(
                     [
                         RepoCommitEvidence(
                             path[1],
                             path[0],
-                            DAY * 2,
+                            ttl,
                             (
                                 f'Github recent commits for {repo} repo '
                                 f'{branch} branch'

--- a/arboretum/auditree/templates/reports/auditree/filepath_new_commits.md.tmpl
+++ b/arboretum/auditree/templates/reports/auditree/filepath_new_commits.md.tmpl
@@ -1,0 +1,47 @@
+{#- -*- mode:jinja2; coding: utf-8 -*- -#}
+{#
+Copyright (c) 2020 IBM Corp. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+# {{ test.title }} Report {{ now.strftime('%Y-%m-%d') }}
+
+This report flags all recent commits made to the following repository branches
+and file paths:
+
+| Repository | Branch | File Path |
+|------------|--------|-----------|
+{%- for repo, branches in test.config.get('org.auditree.repo_integrity.filepaths').items() -%}
+{%- for branch, filepaths in branches.items() -%}
+{% for filepath in filepaths %}
+| `{{ repo }}` | `{{ branch }}` | `{{ filepath }}` |
+{%- endfor -%}
+{%- endfor -%}
+{%- endfor -%}
+
+{% if test.total_issues_count(results) == 0 -%}
+**No new commits to report.**
+{% else -%}
+{% for topic in all_warnings.keys()|sort %}
+
+## {{ topic }}
+{% for warning in all_warnings[topic] %}
+- [{{ warning['sha'] }}]({{ warning['url'] }})
+   - Repository: `{{ warning['repo'] }}`
+   - Branch: `{{ warning['branch'] }}`
+   - Committed By: `{{ warning['author'] }}`
+   - Committed At: `{{ warning['datetime'] }}`
+{%- endfor -%}
+{%- endfor -%}
+{%- endif %}

--- a/arboretum/auditree/templates/reports/auditree/repo_branch_new_commits.md.tmpl
+++ b/arboretum/auditree/templates/reports/auditree/repo_branch_new_commits.md.tmpl
@@ -1,0 +1,44 @@
+{#- -*- mode:jinja2; coding: utf-8 -*- -#}
+{#
+Copyright (c) 2020 IBM Corp. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+# {{ test.title }} Report {{ now.strftime('%Y-%m-%d') }}
+
+This report flags all recent commits made to the following repository branches:
+
+| Repository | Branch |
+|------------|--------|
+{%- for repo, branches in test.config.get('org.auditree.repo_integrity.branches').items() -%}
+{% for branch in branches %}
+| `{{ repo }}` | `{{ branch }}` |
+{%- endfor -%}
+{%- endfor -%}
+
+{% if test.total_issues_count(results) == 0 -%}
+**No new commits to report.**
+{% else -%}
+{% for topic in all_warnings.keys()|sort %}
+
+## {{ topic }}
+{% for warning in all_warnings[topic] %}
+- [{{ warning['sha'] }}]({{ warning['url'] }})
+   - Repository: `{{ warning['repo'] }}`
+   - Branch: `{{ warning['branch'] }}`
+   - Committed By: `{{ warning['author'] }}`
+   - Committed At: `{{ warning['datetime'] }}`
+{%- endfor -%}
+{%- endfor -%}
+{%- endif %}

--- a/arboretum/chef/README.md
+++ b/arboretum/chef/README.md
@@ -4,8 +4,7 @@ The fetchers and checks contained within this `chef` category folder are
 common tests that can be configured and executed for the purpose of generating
 compliance reports and notifications using the [auditree-framework][].  They
 validate the configuration and ensure smooth execution of an auditree instance.
-See [auditree-framework documentation](https://complianceascode.github.io/auditree-framework/)
-for more details.
+See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like
 [Travis CI](https://travis-ci.com/) as part of another project that uses this
@@ -13,8 +12,8 @@ library package as a dependency.
 
 ## Usage as a library
 
-See [usage][usage] for specifics on including this library as a dependency and
-how to include the fetchers and checks from this library in your downstream project.
+See [usage][] for specifics on including this library as a dependency and how
+to include the fetchers and checks from this library in your downstream project.
 
 ## Fetchers
 
@@ -24,4 +23,6 @@ Fetchers coming soon...
 
 Checks coming soon...
 
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
 [usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -2,10 +2,9 @@
 
 The fetchers and checks contained within this `ibm_cloud` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework](https://github.com/ComplianceAsCode/auditree-framework).  They
+compliance reports and notifications using the [auditree-framework][].  They
 validate the configuration and ensure smooth execution of an auditree instance.
-See [auditree-framework documentation](https://complianceascode.github.io/auditree-framework/)
-for more details.
+See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like
 [Travis CI](https://travis-ci.com/) as part of another project that uses this
@@ -13,8 +12,8 @@ library package as a dependency.
 
 ## Usage as a library
 
-See [usage][usage] for specifics on including this library as a dependency and
-how to include the fetchers and checks from this library in your downstream project.
+See [usage][] for specifics on including this library as a dependency and how
+to include the fetchers and checks from this library in your downstream project.
 
 ## Fetchers
 
@@ -24,4 +23,6 @@ Fetchers coming soon...
 
 Checks coming soon...
 
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
 [usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage

--- a/arboretum/kubernetes/README.md
+++ b/arboretum/kubernetes/README.md
@@ -4,8 +4,7 @@ The fetchers and checks contained within this `kubernetes` category folder are
 common tests that can be configured and executed for the purpose of generating
 compliance reports and notifications using the [auditree-framework][].  They
 validate the configuration and ensure smooth execution of an auditree instance.
-See [auditree-framework documentation](https://complianceascode.github.io/auditree-framework/)
-for more details.
+See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like
 [Travis CI](https://travis-ci.com/) as part of another project that uses this
@@ -13,8 +12,8 @@ library package as a dependency.
 
 ## Usage as a library
 
-See [usage][usage] for specifics on including this library as a dependency and
-how to include the fetchers and checks from this library in your downstream project.
+See [usage][] for specifics on including this library as a dependency and how
+to include the fetchers and checks from this library in your downstream project.
 
 ## Fetchers
 
@@ -24,4 +23,6 @@ Fetchers coming soon...
 
 Checks coming soon...
 
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
 [usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage

--- a/arboretum/object_storage/README.md
+++ b/arboretum/object_storage/README.md
@@ -4,8 +4,7 @@ The fetchers and checks contained within this `object_storage` category folder a
 common tests that can be configured and executed for the purpose of generating
 compliance reports and notifications using the [auditree-framework][].  They
 validate the configuration and ensure smooth execution of an auditree instance.
-See [auditree-framework documentation](https://complianceascode.github.io/auditree-framework/)
-for more details.
+See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like
 [Travis CI](https://travis-ci.com/) as part of another project that uses this
@@ -13,7 +12,7 @@ library package as a dependency.
 
 ## Usage as a library
 
-See [usage][usage] for specifics on including this library as a dependency and
+See [usage][] for specifics on including this library as a dependency and
 how to include the fetchers and checks from this library in your downstream project.
 
 ## Fetchers
@@ -24,4 +23,6 @@ Fetchers coming soon...
 
 Checks coming soon...
 
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
 [usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage

--- a/arboretum/pager_duty/README.md
+++ b/arboretum/pager_duty/README.md
@@ -4,8 +4,7 @@ The fetchers and checks contained within this `pager_duty` category folder are
 common tests that can be configured and executed for the purpose of generating
 compliance reports and notifications using the [auditree-framework][].  They
 validate the configuration and ensure smooth execution of an auditree instance.
-See [auditree-framework documentation](https://complianceascode.github.io/auditree-framework/)
-for more details.
+See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like
 [Travis CI](https://travis-ci.com/) as part of another project that uses this
@@ -13,8 +12,8 @@ library package as a dependency.
 
 ## Usage as a library
 
-See [usage][usage] for specifics on including this library as a dependency and
-how to include the fetchers and checks from this library in your downstream project.
+See [usage][] for specifics on including this library as a dependency and how
+to include the fetchers and checks from this library in your downstream project.
 
 ## Fetchers
 
@@ -24,4 +23,6 @@ Fetchers coming soon...
 
 Checks coming soon...
 
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
 [usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage

--- a/arboretum/splunk/README.md
+++ b/arboretum/splunk/README.md
@@ -4,8 +4,7 @@ The fetchers and checks contained within this `splunk` category folder are
 common tests that can be configured and executed for the purpose of generating
 compliance reports and notifications using the [auditree-framework][].  They
 validate the configuration and ensure smooth execution of an auditree instance.
-See [auditree-framework documentation](https://complianceascode.github.io/auditree-framework/)
-for more details.
+See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like
 [Travis CI](https://travis-ci.com/) as part of another project that uses this
@@ -13,8 +12,8 @@ library package as a dependency.
 
 ## Usage as a library
 
-See [usage][usage] for specifics on including this library as a dependency and
-how to include the fetchers and checks from this library in your downstream project.
+See [usage][] for specifics on including this library as a dependency and how
+to include the fetchers and checks from this library in your downstream project.
 
 ## Fetchers
 
@@ -24,4 +23,6 @@ Fetchers coming soon...
 
 Checks coming soon...
 
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
 [usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage

--- a/controls.json
+++ b/controls.json
@@ -23,5 +23,15 @@
     "auditree_evidence": {
       "auditree_control": ["arboretum.auditree"]
     }
+  },
+  "arboretum.auditree.checks.test_repo_branch_commits.RepoBranchNewCommitsCheck": {
+    "auditree_evidence": {
+      "auditree_control": ["arboretum.auditree"]
+    }
+  },
+  "arboretum.auditree.checks.test_filepath_commits.FilepathNewCommitsCheck": {
+    "auditree_evidence": {
+      "auditree_control": ["arboretum.auditree"]
+    }
   }
 }

--- a/devel.json
+++ b/devel.json
@@ -12,9 +12,15 @@
     "name": "MY-ORG",
     "auditree": {
       "repo_integrity": {
+        "branches": {
+          "https://github.com/ComplianceAsCode/auditree-arboretum": ["main"]
+        },
         "filepaths": {
           "https://github.com/ComplianceAsCode/auditree-arboretum": {
-            "main": ["arboretum/common/constants.py"]
+            "main": [
+              "arboretum/common/constants.py",
+              "arboretum/auditree"
+            ]
           }
         }
       }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Add repository/branch new commits check.
- Add repository/branch/filepath new commits check.
- Github repository/branch recent commits fetcher now fetches since evidence last update.
- Github repo recent commits evidence: TTL set to 2 days for locker, 1 day all other repos.
- Links to the `auditree-framework` in README.md files are correct now.

## Why

This allows for the monitoring of possibly unexpected new commits going into repositories.

## How

- Added repository/branch new commits check.
- Added repository/branch/filepath new commits check.
- Updated Github repository/branch recent commits fetcher to fetch based on evidence last update.
- Updated Github repo recent commits evidence where TTL is set to 2 days for locker and 1 day all other repos.
- Fixed links to the `auditree-framework` in all README.md files.

## Test

- Fetcher functionality outwardly preserved and fetches based on evidence last update as expected
- New checks both warn as expected and reports generated are accurate and readable

## Context

Closes #18 
