### PR TITLE
Add repo integrity evidence unit tests

### DIFF
--- a/test/fixtures/gh_repo_commits.json
+++ b/test/fixtures/gh_repo_commits.json
@@ -1,0 +1,17 @@
+[
+  {
+    "author": {},
+    "commit": {
+      "author": {
+        "name": "The Dude",
+        "date": "2020-08-20T12:12:12Z"
+      },
+      "verification": {
+        "verified": true
+      }
+    },
+    "sha": "a123456789",
+    "html_url": "https://the-commit-url",
+    "other_stuff": {}
+  }
+]

--- a/test/fixtures/gh_repo_metadata.json
+++ b/test/fixtures/gh_repo_metadata.json
@@ -1,0 +1,13 @@
+{
+  "pushed_at": "ignore",
+  "size": "ignore",
+  "updated_at": "ignore",
+  "stargazers_count": "ignore",
+  "subscribers_count": "ignore",
+  "watchers": "ignore",
+  "watchers_count": "ignore",
+  "open_issues": "ignore",
+  "open_issues_count": "ignore",
+  "size": 12345,
+  "foo": "bar"
+}

--- a/test/test_evidences/test_repo_branch_protection.py
+++ b/test/test_evidences/test_repo_branch_protection.py
@@ -1,0 +1,88 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repo branch protection evidence unit tests."""
+
+import unittest
+
+from arboretum.auditree.evidences.repo_branch_protection import (
+    RepoBranchProtectionEvidence
+)
+
+
+class RepoBranchProtectionEvidenceTest(unittest.TestCase):
+    """RepoBranchProtectionEvidence unit tests."""
+
+    def test_no_content(self):
+        """Ensure properties requiring content return None when no content."""
+        evidence = RepoBranchProtectionEvidence('gh_foo.json', 'bar')
+        self.assertIsNone(evidence.admin_enforce)
+        self.assertIsNone(evidence.signed_commits_required)
+        self.assertIsNone(evidence.as_a_dict)
+
+    def test_gl_not_implemented(self):
+        """Ensure NotImplementedError raised for Gitlab."""
+        evidence = RepoBranchProtectionEvidence('gl_foo.json', 'bar')
+        evidence.set_content('{"matters": "not"}')
+        gl_err_msg = 'Support for Gitlab coming soon...'
+        with self.assertRaises(NotImplementedError) as ae:
+            _ = evidence.admin_enforce
+        self.assertEqual(str(ae.exception), gl_err_msg)
+        with self.assertRaises(NotImplementedError) as scr:
+            _ = evidence.signed_commits_required
+        self.assertEqual(str(scr.exception), gl_err_msg)
+
+    def test_bb_not_implemented(self):
+        """Ensure NotImplementedError raised for Bitbucket."""
+        evidence = RepoBranchProtectionEvidence('bb_foo.json', 'bar')
+        evidence.set_content('{"matters": "not"}')
+        gl_err_msg = 'Support for Bitbucket coming soon...'
+        with self.assertRaises(NotImplementedError) as ae:
+            _ = evidence.admin_enforce
+        self.assertEqual(str(ae.exception), gl_err_msg)
+        with self.assertRaises(NotImplementedError) as scr:
+            _ = evidence.signed_commits_required
+        self.assertEqual(str(scr.exception), gl_err_msg)
+
+    def test_as_a_dict(self):
+        """Ensure dict returned when content is present."""
+        evidence = RepoBranchProtectionEvidence('gh_foo.json', 'bar')
+        evidence.set_content('{"foo": "bar"}')
+        self.assertEqual(evidence.as_a_dict, {'foo': 'bar'})
+
+    def test_admin_enforce(self):
+        """Ensure enforce admin details returned."""
+        evidence = RepoBranchProtectionEvidence('gh_foo.json', 'bar')
+        evidence.set_content('{"foo": "bar"}')
+        self.assertFalse(evidence.admin_enforce)
+        evidence.set_content('{"enforce_admins": {"enabled": true}}')
+        # False expected because as_a_dict content already fetched
+        self.assertFalse(evidence.admin_enforce)
+        evidence = RepoBranchProtectionEvidence('gh_foo.json', 'bar')
+        evidence.set_content('{"enforce_admins": {"enabled": true}}')
+        # True expected because evidence is a new object
+        self.assertTrue(evidence.admin_enforce)
+
+    def test_signed_commits_required(self):
+        """Ensure enforce admin details returned."""
+        evidence = RepoBranchProtectionEvidence('gh_foo.json', 'bar')
+        evidence.set_content('{"foo": "bar"}')
+        self.assertFalse(evidence.signed_commits_required)
+        evidence.set_content('{"required_signatures": {"enabled": true}}')
+        # False expected because as_a_dict content already fetched
+        self.assertFalse(evidence.signed_commits_required)
+        evidence = RepoBranchProtectionEvidence('gh_foo.json', 'bar')
+        evidence.set_content('{"required_signatures": {"enabled": true}}')
+        # True expected because evidence is a new object
+        self.assertTrue(evidence.signed_commits_required)

--- a/test/test_evidences/test_repo_commit.py
+++ b/test/test_evidences/test_repo_commit.py
@@ -1,0 +1,95 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repo commit evidence unit tests."""
+
+import unittest
+
+from arboretum.auditree.evidences.repo_commit import RepoCommitEvidence
+
+
+class RepoCommitEvidenceTest(unittest.TestCase):
+    """RepoCommitEvidence unit tests."""
+
+    def test_no_content(self):
+        """Ensure properties requiring content return None when no content."""
+        evidence = RepoCommitEvidence('gh_foo.json', 'bar')
+        self.assertIsNone(evidence.signed_status)
+        self.assertIsNone(evidence.author_info)
+        self.assertIsNone(evidence.as_a_list)
+
+    def test_gl_not_implemented(self):
+        """Ensure NotImplementedError raised for Gitlab."""
+        evidence = RepoCommitEvidence('gl_foo.json', 'bar')
+        evidence.set_content('{"matters": "not"}')
+        gl_err_msg = 'Support for Gitlab coming soon...'
+        with self.assertRaises(NotImplementedError) as ss:
+            _ = evidence.signed_status
+        self.assertEqual(str(ss.exception), gl_err_msg)
+        with self.assertRaises(NotImplementedError) as ai:
+            _ = evidence.author_info
+        self.assertEqual(str(ai.exception), gl_err_msg)
+
+    def test_bb_not_implemented(self):
+        """Ensure NotImplementedError raised for Bitbucket."""
+        evidence = RepoCommitEvidence('bb_foo.json', 'bar')
+        evidence.set_content('{"matters": "not"}')
+        gl_err_msg = 'Support for Bitbucket coming soon...'
+        with self.assertRaises(NotImplementedError) as ss:
+            _ = evidence.signed_status
+        self.assertEqual(str(ss.exception), gl_err_msg)
+        with self.assertRaises(NotImplementedError) as ai:
+            _ = evidence.author_info
+        self.assertEqual(str(ai.exception), gl_err_msg)
+
+    def test_as_a_list(self):
+        """Ensure dict returned when content is present."""
+        evidence = RepoCommitEvidence('gh_foo.json', 'bar')
+        evidence.set_content('[{"foo": "bar"}]')
+        self.assertEqual(evidence.as_a_list, [{'foo': 'bar'}])
+
+    def test_signed_status(self):
+        """Ensure commit signed details returned."""
+        evidence = RepoCommitEvidence('gh_foo.json', 'bar')
+        evidence.set_content(
+            open('./test/fixtures/gh_repo_commits.json').read()
+        )
+        self.assertEqual(
+            evidence.signed_status,
+            [
+                {
+                    'sha': 'a123456789',
+                    'url': 'https://the-commit-url',
+                    'signed': True
+                }
+            ]
+        )
+
+    def test_author_info(self):
+        """Ensure commit author details returned."""
+        evidence = RepoCommitEvidence('gh_foo.json', 'bar')
+        evidence.set_content(
+            open('./test/fixtures/gh_repo_commits.json').read()
+        )
+        self.assertEqual(
+            evidence.author_info,
+            [
+                {
+                    'sha': 'a123456789',
+                    'url': 'https://the-commit-url',
+                    'author': 'The Dude',
+                    'datetime': '2020-08-20T12:12:12Z'
+                }
+            ]
+        )

--- a/test/test_evidences/test_repo_metadata.py
+++ b/test/test_evidences/test_repo_metadata.py
@@ -1,0 +1,64 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repo metadata evidence unit tests."""
+
+import json
+import unittest
+
+from arboretum.auditree.evidences.repo_metadata import RepoMetadataEvidence
+
+
+class RepoMetadataEvidenceTest(unittest.TestCase):
+    """RepoMetadataEvidence unit tests."""
+
+    def test_no_content(self):
+        """Ensure properties requiring content return None when no content."""
+        evidence = RepoMetadataEvidence('gh_foo.json', 'bar')
+        self.assertIsNone(evidence.repo_size)
+        self.assertIsNone(evidence.filtered_content)
+
+    def test_gl_not_implemented(self):
+        """Ensure NotImplementedError raised for Gitlab."""
+        evidence = RepoMetadataEvidence('gl_foo.json', 'bar')
+        evidence.set_content('{"matters": "not"}')
+        gl_err_msg = 'Support for Gitlab coming soon...'
+        with self.assertRaises(NotImplementedError) as rs:
+            _ = evidence.repo_size
+        self.assertEqual(str(rs.exception), gl_err_msg)
+
+    def test_bb_not_implemented(self):
+        """Ensure NotImplementedError raised for Bitbucket."""
+        evidence = RepoMetadataEvidence('bb_foo.json', 'bar')
+        evidence.set_content('{"matters": "not"}')
+        gl_err_msg = 'Support for Bitbucket coming soon...'
+        with self.assertRaises(NotImplementedError) as rs:
+            _ = evidence.repo_size
+        self.assertEqual(str(rs.exception), gl_err_msg)
+
+    def test_repo_size(self):
+        """Ensure repo size is returned."""
+        evidence = RepoMetadataEvidence('gh_foo.json', 'bar')
+        evidence.set_content(
+            open('./test/fixtures/gh_repo_metadata.json').read()
+        )
+        self.assertEqual(evidence.repo_size, 12345)
+
+    def test_filtered_content(self):
+        """Ensure all IGNORED_REPO_METADATA fields are parsed out."""
+        evidence = RepoMetadataEvidence('gh_foo.json', 'bar')
+        evidence.set_content(
+            open('./test/fixtures/gh_repo_metadata.json').read()
+        )
+        self.assertEqual(json.loads(evidence.filtered_content), {'foo': 'bar'})


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add repo integrity evidence unit tests

## Why

Unit tests are good

## How

Add repo integrity evidence unit tests

## Test

All tests complete successfully and provide full coverage of their respective evidence classes.

## Context

Closes #21 
