### PR TITLE
Tweak recent commits checks report templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 0.5.1
+
+- [IMPROVED] Updated template layout for Repository/Branch New Commits report.
+- [IMPROVED] Updated template layout for Repository/Branch/Filepath New Commits report.
+
 # 0.5.0
 
 - [NEW] Add repository/branch new commits check.

--- a/arboretum/__init__.py
+++ b/arboretum/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Arboretum - Checking your compliance & security posture, continuously."""
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/arboretum/auditree/templates/reports/auditree/filepath_new_commits.md.tmpl
+++ b/arboretum/auditree/templates/reports/auditree/filepath_new_commits.md.tmpl
@@ -30,9 +30,10 @@ and file paths:
 {%- endfor -%}
 {%- endfor -%}
 
-{% if test.total_issues_count(results) == 0 -%}
+{% if test.total_issues_count(results) == 0 %}
+
 **No new commits to report.**
-{% else -%}
+{% else %}
 {% for topic in all_warnings.keys()|sort %}
 
 ## {{ topic }}

--- a/arboretum/auditree/templates/reports/auditree/repo_branch_new_commits.md.tmpl
+++ b/arboretum/auditree/templates/reports/auditree/repo_branch_new_commits.md.tmpl
@@ -27,9 +27,10 @@ This report flags all recent commits made to the following repository branches:
 {%- endfor -%}
 {%- endfor -%}
 
-{% if test.total_issues_count(results) == 0 -%}
+{% if test.total_issues_count(results) == 0 %}
+
 **No new commits to report.**
-{% else -%}
+{% else %}
 {% for topic in all_warnings.keys()|sort %}
 
 ## {{ topic }}


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Updated template layout for Repository/Branch New Commits report.
- Updated template layout for Repository/Branch/Filepath New Commits report.

## Why

When no issues found, report wasn't rendering the success message.

## How

- Add proper spacing to both templates

## Test

- Reports both render as expected now for success and warning conditions

## Context

N/A
