### PR TITLE
Ensure Auditree checks are tracking evidence used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,19 @@
-# 0.6.0 (2020-09-08)
+# [0.6.1](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.6.1)
+
+- [FIXED] Auditree Abandoned Evidence check now tracks all evidence used by check.
+- [FIXED] Auditree Locker Repo Integrity check now tracks all evidence used by check.
+- [FIXED] Auditree Python Packages check now tracks all evidence used by check.
+
+# [0.6.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.6.0)
 
 - [ADDED] IBM Cloud cluster list fetcher added.
 
-# 0.5.1 (2020-08-28)
+# [0.5.1](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.5.1)
 
 - [CHANGED] Template layout for Repository/Branch New Commits report updated.
 - [CHANGED] Template layout for Repository/Branch/Filepath New Commits report updated.
 
-# 0.5.0 (2020-08-19)
+# [0.5.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.5.0)
 
 - [ADDED] Repository/branch new commits check added.
 - [ADDED] Repository/branch/filepath new commits check added.
@@ -16,7 +22,7 @@
 - [CHANGED] Github repo recent commits evidence: TTL set to 2 days for locker, 1 day all other repos.
 - [FIXED] Links to the `auditree-framework` in README.md files are correct now.
 
-# 0.4.0 (2020-08-14)
+# [0.4.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.4.0)
 
 - [ADDED] Github repository metadata fetcher added.
 - [ADDED] Github repository recent commits fetcher added.
@@ -24,7 +30,7 @@
 - [ADDED] Evidence locker repository integrity checks added.
 - [ADDED] Evidence locker recent commits integrity checks added.
 
-# 0.3.0 (2020-07-31)
+# [0.3.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.3.0)
 
 - [BREAKING] Moved `auditree` fetchers and checks up to arboretum.auditree.
 - [ADDED] Folder hierarchy for Ansible fetchers, checks, and harvest reports added.
@@ -35,15 +41,15 @@
 - [ADDED] Folder hierarchy for Pager Duty fetchers, checks, and harvest reports added.
 - [ADDED] Folder hierarchy for Splunk fetchers, checks, and harvest reports added.
 
-# 0.2.0 (2020-07-31)
+# [0.2.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.2.0)
 
 - [ADDED] Python packages fetcher and check added.
 
-# 0.1.0 (2020-07-30)
+# [0.1.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.1.0)
 
 - [ADDED] Compliance configuration fetcher and check added.
 
-# 0.0.1 (2020-07-29)
+# [0.0.1](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.0.1)
 
 - [ADDED] Abandoned evidence fetcher and check added.
 - [ADDED] Made the Auditree Arboretum library public.

--- a/arboretum/__init__.py
+++ b/arboretum/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Arboretum - Checking your compliance & security posture, continuously."""
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/arboretum/auditree/checks/test_abandoned_evidence.py
+++ b/arboretum/auditree/checks/test_abandoned_evidence.py
@@ -84,10 +84,9 @@ class AbandonedEvidenceCheck(ComplianceCheck):
             previous_evidence = None
             try:
                 current_evidence = self.locker.get_evidence(ae_path)
-                previous_evidence = self.locker.get_evidence(
-                    ae_path,
-                    ignore_ttl=True,
-                    evidence_dt=datetime.utcnow() - timedelta(days=1)
+                self.add_evidence_metadata(current_evidence.path)
+                previous_evidence = self.get_historical_evidence(
+                    ae_path, datetime.utcnow() - timedelta(days=1)
                 )
                 self._test_with_history(current_evidence, previous_evidence)
             except EvidenceNotFoundError:

--- a/arboretum/auditree/checks/test_locker_repo_integrity.py
+++ b/arboretum/auditree/checks/test_locker_repo_integrity.py
@@ -81,8 +81,8 @@ class LockerRepoIntegrityCheck(ComplianceCheck):
                 evidence_found = True
                 previous_dt = datetime.utcnow() - timedelta(days=1)
                 try:
-                    previous_raw = self.locker.get_evidence(
-                        path, ignore_ttl=True, evidence_dt=previous_dt
+                    previous_raw = self.get_historical_evidence(
+                        path, previous_dt
                     )
                 except ValueError:
                     self.add_failures(

--- a/arboretum/auditree/checks/test_python_packages.py
+++ b/arboretum/auditree/checks/test_python_packages.py
@@ -59,10 +59,8 @@ class PythonPackageCheck(ComplianceCheck):
         yesterday = None
         yesterday_dt = datetime.utcnow() - timedelta(days=1)
         try:
-            yesterday = self.locker.get_evidence(
-                'raw/auditree/python_packages.json',
-                ignore_ttl=True,
-                evidence_dt=yesterday_dt
+            yesterday = self.get_historical_evidence(
+                'raw/auditree/python_packages.json', yesterday_dt
             )
         except ValueError:
             self.add_warnings(


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Ensure Auditree checks are tracking evidence used

## Why

So that check results, report metadata, and TOC have accurate accounts of evidence used by checks.

## How

- Use the ComplianceCheck.get_historical_evidence helper when retrieving historical evidence
- Either use check helper decorators or context managers for handling evidence within checks or explicitly add evidence metadata to the check (Done in abandoned evidence check).

## Test

- All evidence now being tracked (TOC contains all evidence including historical)
- Check behavior functions the same otherwise
- Reports are accurate

## Context

Closes #35 
