### PR TITLE
Add Github issues fetcher and Zenhub workspaces fetcher

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         files: "^(arboretum|test)"
         stages: [commit]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
     -   id: flake8
         args: [

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# [0.7.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.7.0)
+
+- [ADDED] Folder hierarchy for Issue Management related fetchers, checks, and harvest reports added.
+- [ADDED] Github issues fetcher added to Issue Management.
+- [ADDED] Zenhub workspaces fetcher added to Issue Management.
+
 # [0.6.2](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.6.2)
 
 - [ADDED] Folder hierarchy for Permissions related fetchers, checks, and harvest reports added.

--- a/arboretum/ansible/README.md
+++ b/arboretum/ansible/README.md
@@ -2,8 +2,7 @@
 
 The fetchers and checks contained within this `ansible` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework][].  They
-validate the configuration and ensure smooth execution of an auditree instance.
+compliance reports and notifications using the [auditree-framework][].
 See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like

--- a/arboretum/chef/README.md
+++ b/arboretum/chef/README.md
@@ -2,8 +2,7 @@
 
 The fetchers and checks contained within this `chef` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework][].  They
-validate the configuration and ensure smooth execution of an auditree instance.
+compliance reports and notifications using the [auditree-framework][].
 See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like

--- a/arboretum/common/constants.py
+++ b/arboretum/common/constants.py
@@ -35,3 +35,9 @@ IGNORE_REPO_METADATA = {
 
 # Evidence locker metadata datetime format
 LOCKER_DTTM_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
+
+# Github host URL
+GH_HOST_URL = 'https://github.com'
+
+# Zenhub public API
+ZH_API_ROOT = 'https://api.zenhub.com'

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -2,8 +2,7 @@
 
 The fetchers and checks contained within this `ibm_cloud` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework][].  They
-validate the configuration and ensure smooth execution of an auditree instance.
+compliance reports and notifications using the [auditree-framework][].
 See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like

--- a/arboretum/issue_mgmt/README.md
+++ b/arboretum/issue_mgmt/README.md
@@ -1,0 +1,238 @@
+# Issue Management library
+
+The fetchers and checks contained within this `issue_mgmt` category folder are
+common tests that can be configured and executed for the purpose of generating
+compliance reports and notifications using the [auditree-framework][].
+See [auditree-framework documentation][] for more details.
+
+These tests are normally executed by a CI/CD system like
+[Travis CI](https://travis-ci.com/) as part of another project that uses this
+library package as a dependency.
+
+## Usage as a library
+
+See [usage][] for specifics on including this library as a dependency and how
+to include the fetchers and checks from this library in your downstream project.
+
+## Fetchers
+
+### Github Issues
+
+* Class: [GithubIssuesFetcher][fetch-gh-issues]
+* Purpose: Store Github issues metadata as evidence in the evidence
+locker.
+* Behavior: For each Github repository specified, an evidence file is stored in
+the locker containing the issues for that Github repository based on the provided
+search criteria.  TTL is set to 1 day.
+* Configuration elements:
+   * `org.issue_mgmt.github`
+      * Required
+      * `is:issue` is applied to all retrieval configuration to limit retrieval
+      to Github issues by default.  See the `search` option to expand retrieval
+      to pull requests.
+      * List of dictionaries each containing issue retrieval configuration.
+         * `repo`
+            * Required
+            * String in the form of `owner/repo`.
+            * Use to define the Github repository from where issues will be
+            extracted.
+         * `host`
+            * Optional
+            * String in the form of `https://github.my_org.com`.
+            * Defaults to `https://github.com` (public Github)
+            * Use if the repo is a Github Enterprise repo otherwise do not include.
+         * `states`
+            * Optional
+            * List of string in the form of `["open", "closed"]`.
+            * Valid list element values are `"open"` and `"closed"`.
+            * Values are applied as `OR` logic to the search for issues.
+            * Defaults to `["open"]`.
+            * Use if looking to retrieve closed or both open and closed issues
+            otherwise do not include.
+         * `labels`
+            * Optional
+            * Dictionary of string key/value pairs
+               * Valid keys: `"equals"`, `"contains"`, `"startswith"`, and
+               `"endswith"`.
+               * Valid values: List of strings
+               * Each pair is applied as `OR` logic to the search for issues.
+            * Defaults to all labels.
+            * Use if looking to limit issues to issues containing specific labels
+            other do not include.
+         * `search`
+            * Optional
+            * String in the form of a [Github search query string][gh-issues-search].
+               * Use of `search` overrides all other configuration.
+               * `is:issue` is automatically prepended to every search query
+               provided.
+            * Use if looking for finer granularity in your Github issue search
+            criteria otherwise do not include.
+
+* Example configuration:
+
+   ```json
+   {
+     "org": {
+       "issue_mgmt": {
+         "github": [
+           {
+             "repo": "foo-owner/foo-repo",
+             "host": "https://github.foo.com",
+             "states": ["open", "closed"],
+             "labels": {
+               "equals": ["label-one", "label-two"],
+               "contains": ["foo"],
+               "startswith": ["bar"],
+               "endswith": ["baz"]
+             }
+           },
+           {
+             "repo": "bar-owner/bar-repo",
+             "search": "is:open is:closed in:title 'words in my title'"
+           }
+         ]
+       }
+     }
+   }
+   ```
+
+* Required credentials:
+   * `github` or `github_enterprise` credentials with read permissions to the
+   repository are required for this fetcher to successfully retrieve evidence.
+      * `username`: The Github user used to run the fetcher.
+      * `token`: The Github user access token used to run the fetcher.
+   * Example credentials file entry:
+
+      ```ini
+      [github]
+      username=gh-user-name
+      token=gh-access-token
+      ```
+
+      or
+
+      ```ini
+      [github_enterprise]
+      username=ghe-user-name
+      token=ghe-access-token
+      ```
+
+   * NOTE: These credentials are also needed for basic configuration of the
+   Auditree framework.  The expectation is that the same credentials are used
+   for all Github interactions.
+
+* Import statement:
+
+   ```python
+   from arboretum.issue_mgmt.fetchers.fetch_github_issues import GithubIssuesFetcher
+   ```
+
+### Zenhub Workspaces
+
+* Class: [ZenhubWorkspacesFetcher][fetch-zh-workspaces]
+* Purpose: Store Zenhub workspaces metadata as evidence in the evidence
+locker.
+* Behavior: For each Github repository specified, an evidence file is stored in
+the locker containing the Zenhub workspace boards specified.  TTL is set to 1 day.
+* Configuration elements:
+   * `org.issue_mgmt.zenhub`
+      * Required
+      * List of dictionaries each containing workspace retrieval configuration.
+         * `github_repo`
+            * Required
+            * String in the form of `owner/repo`.
+            * Use to define the target Github repository for which workspaces
+            are retrieved.
+         * `github_host`
+            * Optional
+            * String in the form of `https://github.my_org.com`.
+            * Defaults to `https://github.com` (public Github)
+            * Use if the repo is a Github Enterprise repo otherwise do not include.
+         * `api_root`
+            * Optional
+            * String in the form of `https://zenhub.my_org.com`.
+            * Defaults to `https://api.zenhub.com/` (public Zenhub API)
+            * Use if the target is Zenhub Enterprise otherwise do not include.
+         * `workspaces`
+            * Optional
+            * List of strings
+            * Valid values in the list include valid Zenhub workspace names for
+            the given Github repository.
+            * Use if looking to limit workspace retrieval to a subset of workspaces
+            otherwise do not include.
+
+* Example configuration:
+
+   ```json
+   {
+     "org": {
+       "issue_mgmt": {
+         "zenhub": [
+           {
+             "github_repo": "foo-owner/foo-repo",
+             "github_host": "https://github.foo.com",
+             "api_root": "https://zenhub.foo.com",
+             "workspaces": ["My super cool foo workspace"]
+           },
+           {
+             "github_repo": "bar-owner/bar-repo",
+             "workspaces": ["My super cool bar workspace", "Some other workspace"]
+           }
+         ]
+       }
+     }
+   }
+   ```
+
+* Required credentials:
+   * `github` or `github_enterprise` credentials with read permissions to the
+   repository are required for this fetcher to successfully retrieve evidence.
+      * `username`: The Github user used to run the fetcher.
+      * `token`: The Github user access token used to run the fetcher.
+   * `zenhub` or `zenhub_enterprise` credentials with read permissions to the
+   Zenhub API are required for this fetcher to successfully retrieve evidence.
+   * Example credentials file entry:
+
+      ```ini
+      [github]
+      username=gh-user-name
+      token=gh-access-token
+
+      [zenhub]
+      token=zh-access-token
+      ```
+
+      or
+
+      ```ini
+      [github_enterprise]
+      username=ghe-user-name
+      token=ghe-access-token
+
+      [zenhub_enterprise]
+      token=zhe-access-token
+      ```
+
+   * NOTE: The Github credentials are also needed for basic configuration of the
+   Auditree framework.  The expectation is that the same credentials are used
+   for all Github interactions.
+   * NOTE: See [Zenhub API Authentication][zh-auth] for details on generating
+   Zenhub API tokens.
+
+* Import statement:
+
+   ```python
+   from arboretum.issue_mgmt.fetchers.fetch_zenhub_workspaces import ZenhubWorkspacesFetcher
+   ```
+
+## Checks
+
+Checks coming soon...
+
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
+[usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage
+[fetch-gh-issues]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/issue_mgmt/fetchers/fetch_github_issues.py
+[fetch-zh-workspaces]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/issue_mgmt/fetchers/fetch_zenhub_workspaces.py
+[gh-issues-search]: https://docs.github.com/en/free-pro-team@latest/github/searching-for-information-on-github/searching-issues-and-pull-requests
+[zh-auth]: https://github.com/ZenHubIO/API#authentication

--- a/arboretum/issue_mgmt/__init__.py
+++ b/arboretum/issue_mgmt/__init__.py
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.7.0'
+"""Issue Management fetchers, checks, and harvest reports."""

--- a/arboretum/issue_mgmt/checks/__init__.py
+++ b/arboretum/issue_mgmt/checks/__init__.py
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.7.0'
+"""Issue Management validation checks."""

--- a/arboretum/issue_mgmt/evidences/__init__.py
+++ b/arboretum/issue_mgmt/evidences/__init__.py
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.7.0'
+"""Issue Management evidence helper modules/classes."""

--- a/arboretum/issue_mgmt/fetchers/__init__.py
+++ b/arboretum/issue_mgmt/fetchers/__init__.py
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.7.0'
+"""Issue Management evidence gathering fetchers."""

--- a/arboretum/issue_mgmt/fetchers/fetch_github_issues.py
+++ b/arboretum/issue_mgmt/fetchers/fetch_github_issues.py
@@ -1,0 +1,93 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Github repository issues fetcher."""
+
+import json
+
+from arboretum.common.constants import GH_HOST_URL
+
+from compliance.evidence import DAY, RawEvidence, raw_evidence
+from compliance.fetch import ComplianceFetcher
+from compliance.utils.data_parse import get_sha256_hash
+from compliance.utils.services.github import Github
+
+
+class GithubIssuesFetcher(ComplianceFetcher):
+    """Fetch Github repository issues."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialize the fetcher object with configuration settings."""
+        cls.gh_pool = {}
+        cls.configs = cls.config.get('org.issue_mgmt.github')
+        return cls
+
+    def fetch_issues(self):
+        """Fetch Github repository issues."""
+        for config in self.configs:
+            host = config.get('host', GH_HOST_URL)
+            repo = config['repo']
+            fname = f'gh_repo_{get_sha256_hash([host, repo], 10)}_issues.json'
+            self.config.add_evidences(
+                [
+                    RawEvidence(
+                        fname,
+                        'issues',
+                        DAY,
+                        f'Github issues for {host}/{repo} repository'
+                    )
+                ]
+            )
+            with raw_evidence(self.locker, f'issues/{fname}') as evidence:
+                if evidence:
+                    if host not in self.gh_pool.keys():
+                        self.gh_pool[host] = Github(base_url=host)
+                    issues = []
+                    for search in self._compose_searches(config, host):
+                        issue_ids = [i['id'] for i in issues]
+                        for result in self.gh_pool[host].search_issues(search):
+                            if result['id'] not in issue_ids:
+                                issues.append(result)
+                    evidence.set_content(json.dumps(issues))
+
+    def _compose_searches(self, config, host):
+        base = f'repo:{config["repo"]} is:issue'
+        if 'search' in config.keys():
+            return [f'{base} {config["search"]}']
+        searches = []
+        for state in config.get('state', ['open']):
+            base += f' is:{state}'
+        for label in self._get_labels(config, host):
+            searches.append(f'{base} label:"{label}"')
+        return searches
+
+    def _get_labels(self, config, host):
+        if not config.get('labels'):
+            return []
+        repo = config['repo']
+        path = f'repos/{repo}/labels'
+        all_label_content = self.gh_pool[host].paginate_api(path)
+        all_labels = [label['name'] for label in all_label_content]
+        label_filters = {
+            'equals': lambda lbl: lbl == _label,
+            'contains': lambda lbl: _label in lbl,
+            'startswith': lambda lbl: lbl.startswith(_label),
+            'endswith': lambda lbl: lbl.endswith(_label)
+        }
+        labels = set()
+        for operator, config_labels in config['labels'].items():
+            for _label in config_labels:
+                labels.update(filter(label_filters[operator], all_labels))
+        return list(labels)

--- a/arboretum/issue_mgmt/fetchers/fetch_zenhub_workspaces.py
+++ b/arboretum/issue_mgmt/fetchers/fetch_zenhub_workspaces.py
@@ -1,0 +1,100 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Github repository Zenhub workspaces fetcher."""
+
+import json
+
+from arboretum.common.constants import GH_HOST_URL, ZH_API_ROOT
+
+from compliance.evidence import DAY, RawEvidence, raw_evidence
+from compliance.fetch import ComplianceFetcher
+from compliance.utils.data_parse import get_sha256_hash
+from compliance.utils.http import BaseSession
+from compliance.utils.services.github import Github
+
+
+class ZenhubWorkspacesFetcher(ComplianceFetcher):
+    """Fetch Zenhub workspaces."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialize the fetcher object with configuration settings."""
+        cls.gh_pool = {}
+        cls.zh_pool = {}
+        cls.configs = cls.config.get('org.issue_mgmt.zenhub')
+        return cls
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up and housekeeping."""
+        for session in cls.zh_pool.values():
+            session.close()
+
+    def fetch_workspaces(self):
+        """Fetch Github repository Zenhub workspaces."""
+        for config in self.configs:
+            gh_host = config.get('github_host', GH_HOST_URL)
+            zh_root = config.get('api_root', ZH_API_ROOT)
+            repo = config['github_repo']
+            repo_hash = get_sha256_hash([gh_host, repo], 10)
+            fname = f'zh_repo_{repo_hash}_workspaces.json'
+            self.config.add_evidences(
+                [
+                    RawEvidence(
+                        fname,
+                        'issues',
+                        DAY,
+                        f'Zenhub workspaces for {gh_host}/{repo} repository'
+                    )
+                ]
+            )
+            with raw_evidence(self.locker, f'issues/{fname}') as evidence:
+                if evidence:
+                    if gh_host not in self.gh_pool.keys():
+                        self.gh_pool[gh_host] = Github(base_url=gh_host)
+                    if zh_root not in self.zh_pool.keys():
+                        self.zh_pool[zh_root] = BaseSession(zh_root)
+                        service = 'zenhub'
+                        if zh_root != ZH_API_ROOT:
+                            service = 'zenhub_enterprise'
+                        token = self.config.creds[service].token
+                        self.zh_pool[zh_root].headers.update(
+                            {
+                                'Content-Type': 'application/json',
+                                'X-Authentication-Token': token
+                            }
+                        )
+                    workspaces = self._get_workspaces(
+                        repo, config.get('workspaces'), gh_host, zh_root
+                    )
+                    evidence.set_content(json.dumps(workspaces))
+
+    def _get_workspaces(self, repo, ws_names, gh_host, zh_root):
+        repo_id = self.gh_pool[gh_host].get_repo_details(repo)['id']
+        resp = self.zh_pool[zh_root].get(
+            f'/p2/repositories/{repo_id}/workspaces'
+        )
+        resp.raise_for_status()
+        workspaces = resp.json()
+        if ws_names:
+            workspaces = [w for w in workspaces if w['name'] in ws_names]
+        results = {}
+        for ws in workspaces:
+            resp = self.zh_pool[zh_root].get(
+                f'/p2/workspaces/{ws["id"]}/repositories/{repo_id}/board'
+            )
+            resp.raise_for_status()
+            results[ws['name']] = resp.json()
+        return results

--- a/arboretum/issue_mgmt/reports/__init__.py
+++ b/arboretum/issue_mgmt/reports/__init__.py
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.7.0'
+"""Issue Management harvest reports and templates."""

--- a/arboretum/issue_mgmt/templates/default.md.tmpl
+++ b/arboretum/issue_mgmt/templates/default.md.tmpl
@@ -1,0 +1,77 @@
+{#- -*- mode:jinja2; coding: utf-8 -*- -#}
+{#
+Copyright (c) 2020 IBM Corp. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+# {{ test.title }} Report {{ now.strftime('%Y-%m-%d') }}
+{% if test.total_issues_count(results) == 0 %}
+No issues found!
+{% else %}
+## Results
+
+{% if test.warnings_for_check_count(results) > 0 -%}
+* [Warnings](#warnings): {{ test.warnings_for_check_count(results) }}
+{% for k in all_warnings.keys() -%}
+    {% if all_warnings[k]|length > 0 -%}
+        {% set anchor = k.lower()|replace(' ', '-') %}
+  * [{{ k|capitalize }}](#{{ anchor }}): {{ all_warnings[k]|length }}
+    {%- endif %}
+{%- endfor -%}
+{% endif %}
+{% if test.failures_for_check_count(results) > 0 %}
+* [Failures](#failures): {{ test.failures_for_check_count(results) }}
+{% for k in all_failures.keys() -%}
+    {% if all_failures[k]|length > 0 -%}
+        {% set anchor = k.lower()|replace(' ', '-') %}
+  * [{{ k|capitalize }}](#{{ anchor }}): {{ all_failures[k]|length }}
+    {%- endif %}
+{%- endfor -%}
+{% endif -%}
+{% endif %}
+
+
+{% if test.warnings_for_check_count(results) > 0 -%}
+## Warnings
+
+{% for type in all_warnings.keys()|sort -%}
+{% if all_warnings[type]|length > 0 %}
+#### {{ type|capitalize }} ####
+{% for at in all_warnings[type]| sort %}
+{% if not link -%}
+* {{ at -}}
+{%- else -%}
+* [{{ at }}]({{ link }}/{{ at }})
+{%- endif %}
+{%- endfor %}
+{% endif -%}
+{% endfor %}
+{% endif %}
+
+{% if test.failures_for_check_count(results) > 0 -%}
+## Failures
+
+{% for type in all_failures.keys()|sort -%}
+{% if all_failures[type]|length > 0 %}
+#### {{ type|capitalize }} ####
+{% for at in all_failures[type]| sort %}
+{% if not link -%}
+* {{ at -}}
+{%- else -%}
+* [{{ at -}}]({{ link }}/{{ at }})
+{%- endif %}
+{%- endfor %}
+{% endif -%}
+{% endfor %}
+{% endif %}

--- a/arboretum/kubernetes/README.md
+++ b/arboretum/kubernetes/README.md
@@ -2,8 +2,7 @@
 
 The fetchers and checks contained within this `kubernetes` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework][].  They
-validate the configuration and ensure smooth execution of an auditree instance.
+compliance reports and notifications using the [auditree-framework][].
 See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like

--- a/arboretum/object_storage/README.md
+++ b/arboretum/object_storage/README.md
@@ -2,8 +2,7 @@
 
 The fetchers and checks contained within this `object_storage` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework][].  They
-validate the configuration and ensure smooth execution of an auditree instance.
+compliance reports and notifications using the [auditree-framework][].
 See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like

--- a/arboretum/pager_duty/README.md
+++ b/arboretum/pager_duty/README.md
@@ -2,8 +2,7 @@
 
 The fetchers and checks contained within this `pager_duty` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework][].  They
-validate the configuration and ensure smooth execution of an auditree instance.
+compliance reports and notifications using the [auditree-framework][].
 See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like

--- a/arboretum/permissions/README.md
+++ b/arboretum/permissions/README.md
@@ -2,8 +2,7 @@
 
 The fetchers and checks contained within this `permissions` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework][].  They
-validate the configuration and ensure smooth execution of an auditree instance.
+compliance reports and notifications using the [auditree-framework][].
 See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like

--- a/arboretum/splunk/README.md
+++ b/arboretum/splunk/README.md
@@ -2,8 +2,7 @@
 
 The fetchers and checks contained within this `splunk` category folder are
 common tests that can be configured and executed for the purpose of generating
-compliance reports and notifications using the [auditree-framework][].  They
-validate the configuration and ensure smooth execution of an auditree instance.
+compliance reports and notifications using the [auditree-framework][].
 See [auditree-framework documentation][] for more details.
 
 These tests are normally executed by a CI/CD system like

--- a/devel.json
+++ b/devel.json
@@ -25,6 +25,37 @@
         }
       }
     },
+    "issue_mgmt": {
+      "github": [
+        {
+          "repo": "foo-owner/foo-repo",
+          "states": ["open", "closed"],
+          "labels": {
+            "equals": ["label-one", "label-two"],
+            "contains": ["label-three"],
+            "startswith": ["label-four"],
+            "endswith": ["label-five"]
+          }
+        },
+        {
+          "host": "https://github.my_org.com",
+          "repo": "bar-owner/bar-repo",
+          "search": "is:open is:closed in:title \"my issue title\""
+        }
+      ],
+      "zenhub": [
+        {
+          "github_repo": "foo-owner/foo-repo",
+          "workspaces": ["My super cool foo workspace"]
+        },
+        {
+          "github_host": "https://github.my_org.com",
+          "github_repo": "bar-owner/bar-repo",
+          "api_root": "https://zenhub.my_org.com",
+          "workspaces": ["My super cool bar workspace", "Some other workspace"]
+        }
+      ]
+    },
     "ibm_cloud": {
       "accounts": ["my_ic_account_one", "my_ic_account_two"]
     }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add Github issues fetcher and Zenhub workspaces fetcher

## Why

- To enable users to fetch issues from a set of Github repositories
- To enable users to fetch Zenhub workspaces for a set of Github repositories

## How

Added Github issues fetcher and Zenhub workspaces fetcher as independent fetchers.  By design each uses its own configuration.

## Test

Both fetchers execute as expected and are independent of each other

## Context

Closes #40 
Closes #41 
