### PR TITLE
Add IBM Cloud Databases list and backups list fetchers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# [0.8.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.8.0)
+
+- [ADDED] IBM Cloud Databases list fetcher added.
+- [ADDED] IBM Cloud Databases backups fetcher added.
+- [ADDED] Folder hierarchy for IBM Cloud Databases fetchers, checks, and harvest reports added.
+
 # [0.7.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.7.0)
 
 - [ADDED] Folder hierarchy for Issue Management related fetchers, checks, and harvest reports added.

--- a/arboretum/common/ibm_constants.py
+++ b/arboretum/common/ibm_constants.py
@@ -22,3 +22,9 @@ IAM_API_KEY_GRANT_TYPE = 'urn:ibm:params:oauth:grant-type:apikey'
 
 # IBM Cloud containers API base URL
 IC_CONTAINERS_BASE_URL = 'https://containers.cloud.ibm.com'
+
+# IBM Cloud Resource controller base URL
+RESOURCE_CONTROLLER_BASE_URL = 'https://resource-controller.cloud.ibm.com'
+
+# formattable string for IBM Cloud Databases url per region
+DB_API_URL = 'https://api.{}.databases.cloud.ibm.com'

--- a/arboretum/ibm_cloud_databases/README.md
+++ b/arboretum/ibm_cloud_databases/README.md
@@ -1,0 +1,99 @@
+# IBM Cloud Databases library
+
+The fetchers and checks contained within this `ibm_cloud_databases` category folder are
+common tests that can be configured and executed for the purpose of generating
+compliance reports and notifications using the [auditree-framework][].  
+See [auditree-framework documentation][] for more details.
+
+These tests are normally executed by a CI/CD system like
+[Travis CI](https://travis-ci.com/) as part of another project that uses this
+library package as a dependency.
+
+## Usage as a library
+
+See [usage][] for specifics on including this library as a dependency and how
+to include the fetchers and checks from this library in your downstream project.
+
+## Fetchers
+
+### IBM Cloud Databases List
+
+* Class: [DatabasesFetcher][fetch-databases]
+* Purpose: Store list of account-specific IBM Cloud databases to the evidence locker.
+* Behavior: Retrieve details about account specific IBM Cloud Databases. TTL for evidence is set to 1 day.
+* Configuration elements:
+  * `org.icd.list.accounts`
+    * Required
+    * List of dictionaries representing the IBM Cloud accounts
+    * Each dictionary must have the following fields
+      * `account_name` - an arbitrary name as a string identifying the IBM Cloud account, used to match to the token provided in the
+      credentials file in order for the fetcher to retrieve content from IBM Cloud for that account.
+      * `resource_group_id` - the resource group id's as a list of strings, associated with the above account name, output of [running the ibmcloud resource groups command][ic-resource-groups] while logged in to an IBM Cloud account.
+
+* Example (required) configuration:
+
+  ```json
+  {
+    "org": {
+      "icd": {
+        "list": {
+          "accounts": [
+            {
+              "account_name": "prod_1234567",
+              "resource_group_id": [
+                                        "bcdef0123456789fedcba1234567890a",
+                                        "a0987654321abcdef9876543210fedcb",
+                                   ]
+            }
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+* Required credentials:
+  * `ibm_cloud` credentials with read/view permissions are needed for this fetcher to successfully retrieve the evidence.
+    * `XXX_api_key`: API key string for account `XXX`.
+    * Example credential file entry:
+
+      ```ini
+      [ibm_cloud]
+      acct_a_api_key=your-ibm-cloud-api-key-for-acct-a
+      acct_b_api_key=your-ibm-cloud-api-key-for-acct-b
+      ```
+
+    * NOTE: API keys can be generated using the [IBM Cloud CLI][ic-api-key-create] or [IBM Cloud Console][ibm-cloud-gen-api-console]. Example to create an API key with IBM Cloud CLI is:
+
+      ```sh
+      ibmcloud iam api-key-create your-iks-api-key-for-acct-x
+      ```
+
+* Import statement:
+
+   ```python
+   from arboretum.ibm_cloud_databases.fetchers.fetch_cluster_list import DatabasesFetcher
+   ```
+
+### IBM Cloud Databases Backups
+
+* Class: [DatabaseBackupsFetcher][fetch-backups]
+* Purpose: Store details of recent backups of account-specific IBM Cloud databases to the evidence locker.
+* Behavior: Retrieves the details of the recent backups as a JSON array. TTL for evidence is set to 1 day.
+* NOTE: This fetcher depends on evidence collected by the [IBM Cloud Databases List fetcher](#ibm-cloud-databases-list), i.e. importing the IBM Cloud Databases List fetcher is a prerequisite for the IBM Cloud Databases Backups fetcher to work.
+
+* Expected configuration elements: See [IBM Cloud Databases List fetcher](#ibm-cloud-databases-list) expected configuration elements.
+
+## Checks
+
+Checks coming soon...
+
+[auditree-framework]: https://github.com/ComplianceAsCode/auditree-framework
+[auditree-framework documentation]: https://complianceascode.github.io/auditree-framework/
+[usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage
+[ic-api-key-create]: https://cloud.ibm.com/docs/cli/reference/ibmcloud?topic=cloud-cli-ibmcloud_commands_iam#ibmcloud_iam_api_key_create
+[fetch-databases]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/ibm_cloud_databases/fetchers/fetch_databases.py
+[fetch-backups]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/ibm_cloud_databases/fetchers/fetch_backups.py
+[ibm-cloud-api]: https://containers.cloud.ibm.com/
+[ibm-cloud-gen-api-console]: https://cloud.ibm.com/docs/account?topic=account-userapikey#create_user_key
+[ic-resource-groups]: https://cloud.ibm.com/docs/cli/reference/ibmcloud?topic=cloud-cli-ibmcloud_cli#global-option-output-examples

--- a/arboretum/ibm_cloud_databases/__init__.py
+++ b/arboretum/ibm_cloud_databases/__init__.py
@@ -1,5 +1,5 @@
 # -*- mode:python; coding:utf-8 -*-
-# Copyright (c) 2020 IBM Corp. All rights reserved.
+# Copyright (c) 2021 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.8.0'
+"""IBM Cloud Databases fetchers, checks, and harvest reports."""

--- a/arboretum/ibm_cloud_databases/checks/__init__.py
+++ b/arboretum/ibm_cloud_databases/checks/__init__.py
@@ -1,5 +1,5 @@
 # -*- mode:python; coding:utf-8 -*-
-# Copyright (c) 2020 IBM Corp. All rights reserved.
+# Copyright (c) 2021 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.8.0'
+"""IBM Cloud Databases validation checks."""

--- a/arboretum/ibm_cloud_databases/evidences/__init__.py
+++ b/arboretum/ibm_cloud_databases/evidences/__init__.py
@@ -1,5 +1,5 @@
 # -*- mode:python; coding:utf-8 -*-
-# Copyright (c) 2020 IBM Corp. All rights reserved.
+# Copyright (c) 2021 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.8.0'
+"""IBM Cloud Databases evidence helper modules/classes."""

--- a/arboretum/ibm_cloud_databases/fetchers/__init__.py
+++ b/arboretum/ibm_cloud_databases/fetchers/__init__.py
@@ -1,5 +1,5 @@
 # -*- mode:python; coding:utf-8 -*-
-# Copyright (c) 2020 IBM Corp. All rights reserved.
+# Copyright (c) 2021 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.8.0'
+"""IBM Cloud Databases evidence gathering fetchers."""

--- a/arboretum/ibm_cloud_databases/fetchers/fetch_backups.py
+++ b/arboretum/ibm_cloud_databases/fetchers/fetch_backups.py
@@ -1,0 +1,133 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2021 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ICD backups fetcher."""
+import json
+from datetime import datetime, timedelta
+from urllib.parse import quote
+
+from arboretum.common.iam_ibm_utils import get_tokens
+from arboretum.common.ibm_constants import DB_API_URL
+
+from compliance.evidence import DAY, RawEvidence
+from compliance.evidence import get_evidence_dependency, raw_evidence
+from compliance.fetch import ComplianceFetcher
+from compliance.utils.http import BaseSession
+
+
+class DatabaseBackupsFetcher(ComplianceFetcher):
+    """Fetches IBM Cloud Databases backups lists."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialize object from config file."""
+        cls.api_sessions = {}
+        cls.accounts = cls.config.get('org.icd.list.accounts')
+        for acct in cls.accounts:
+            acct_name = acct['account_name']
+            cls.config.add_evidences(
+                [
+                    RawEvidence(
+                        f'backups_{acct_name}.json',
+                        'icd',
+                        DAY,
+                        'list of database backups for account'
+                    )
+                ]
+            )
+
+        return cls
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up and housekeeping."""
+        for session in cls.api_sessions.values():
+            session.close()
+
+    def fetch_backups(self):
+        """Fetch IBM Cloud Database backups per account."""
+        now = datetime.utcnow()
+        for acct in self.accounts:
+            acct_name = acct['account_name']
+            evidence_path_main = f'raw/icd/backups_{acct_name}.json'
+            evidence_path_dep = f'raw/icd/databases_{acct_name}.json'
+            start_time = now - timedelta(days=1)
+
+            evidence_metadata = self.locker.get_evidence_metadata(
+                evidence_path_main
+            )
+
+            if evidence_metadata:
+                start_time = datetime.strptime(
+                    evidence_metadata['last_update'], '%Y-%m-%dT%H:%M:%S.%f'
+                )
+
+            with raw_evidence(self.locker, evidence_path_main) as evidence:
+                if evidence:
+                    db_list_raw_evidence = get_evidence_dependency(
+                        evidence_path_dep, self.locker
+                    )
+
+                    backups = []
+                    db_items = json.loads(db_list_raw_evidence.content)
+                    if not isinstance(db_items, list):
+                        db_items = [db_items]
+
+                    for db_item in db_items:
+                        for db in db_item['resources']:
+                            backups.extend(
+                                self._get_backups_list_later_than(
+                                    acct_name, db, start_time
+                                )
+                            )
+
+                    evidence.set_content(json.dumps(backups))
+
+    def _get_backups_list_later_than(self, account, db_obj, start_time):
+        backups_list = self._get_ibmcloud_db_backups_list(account, db_obj)
+
+        if 'backups' in backups_list:
+            return [
+                backup for backup in backups_list['backups']
+                if start_time < datetime.
+                strptime(backup['created_at'], '%Y-%m-%dT%H:%M:%S.%fZ')
+            ]
+
+        return []
+
+    def _get_ibmcloud_db_backups_list(self, account, db_obj):
+
+        # get session for the region if needed
+        region = db_obj['region_id']
+        if region not in self.api_sessions.keys():
+            self.api_sessions[region] = BaseSession(DB_API_URL.format(region))
+            api_key = getattr(
+                self.config.creds['ibm_cloud'], f'{account}_api_key'
+            )
+            self.api_sessions[region].headers.update(
+                {
+                    'Accept': 'application/json',
+                    'Authorization': f'Bearer {get_tokens(api_key)[0]}'
+                }
+            )
+
+        # get database backups list
+        # https://cloud.ibm.com/apidocs/cloud-databases-api/
+        #                       cloud-databases-api-v4#getdeploymentbackups
+        escaped_crn = quote(db_obj['crn'], safe='')
+        resp = self.api_sessions[region].get(
+            f'/v4/ibm/deployments/{escaped_crn}/backups'
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/arboretum/ibm_cloud_databases/fetchers/fetch_databases.py
+++ b/arboretum/ibm_cloud_databases/fetchers/fetch_databases.py
@@ -1,0 +1,87 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2021 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""IBM Cloud Databases list fetcher."""
+import json
+
+from arboretum.common.iam_ibm_utils import get_tokens
+from arboretum.common.ibm_constants import RESOURCE_CONTROLLER_BASE_URL
+
+from compliance.evidence import DAY, RawEvidence, raw_evidence
+from compliance.fetch import ComplianceFetcher
+
+
+class DatabasesFetcher(ComplianceFetcher):
+    """Fetches databases list."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialize object from config file."""
+        cls.accounts = cls.config.get('org.icd.list.accounts')
+        for acct in cls.accounts:
+            acct_name = acct['account_name']
+            cls.config.add_evidences(
+                [
+                    RawEvidence(
+                        f'databases_{acct_name}.json',
+                        'icd',
+                        DAY,
+                        'list of all databases for account'
+                    )
+                ]
+            )
+        headers = {'Accept': 'application/json'}
+        cls.session(RESOURCE_CONTROLLER_BASE_URL, **headers)
+
+        return cls
+
+    def fetch_databases(self):
+        """Fetch IBM Cloud Databases for each account."""
+        for acct in self.accounts:
+            acct_name = acct['account_name']
+            evidence_path = f'raw/icd/databases_{acct_name}.json'
+            resource_group_ids = acct['resource_group_id']
+            if isinstance(resource_group_ids, str):
+                resource_group_ids = [resource_group_ids]
+
+            with raw_evidence(self.locker, evidence_path) as evidence:
+                if evidence:
+                    db_list = []
+                    for resource_group_id in resource_group_ids:
+                        db_list.append(
+                            self._get_ibmcloud_db_list(
+                                acct_name, resource_group_id
+                            )
+                        )
+
+                    evidence.set_content(json.dumps(db_list))
+
+    def _get_ibmcloud_db_list(self, account, resource_group_id):
+
+        # get credential for the account
+        api_key = getattr(self.config.creds['ibm_cloud'], f'{account}_api_key')
+        # get database list
+        # https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+        self.session().headers.update(
+            {'Authorization': f'Bearer {get_tokens(api_key)[0]}'}
+        )
+        resp = self.session().get(
+            '/v1/resource_instances',
+            params={
+                'resource_group_id': resource_group_id,
+                'resource_plan_id': 'databases-for-*'
+            }
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/arboretum/ibm_cloud_databases/reports/__init__.py
+++ b/arboretum/ibm_cloud_databases/reports/__init__.py
@@ -1,5 +1,5 @@
 # -*- mode:python; coding:utf-8 -*-
-# Copyright (c) 2020 IBM Corp. All rights reserved.
+# Copyright (c) 2021 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Arboretum - Checking your compliance & security posture, continuously."""
-
-__version__ = '0.8.0'
+"""IBM Cloud Databases harvest reports and templates."""

--- a/arboretum/ibm_cloud_databases/templates/default.md.tmpl
+++ b/arboretum/ibm_cloud_databases/templates/default.md.tmpl
@@ -1,0 +1,77 @@
+{#- -*- mode:jinja2; coding: utf-8 -*- -#}
+{#
+Copyright (c) 2021 IBM Corp. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+# {{ test.title }} Report {{ now.strftime('%Y-%m-%d') }}
+{% if test.total_issues_count(results) == 0 %}
+No issues found!
+{% else %}
+## Results
+
+{% if test.warnings_for_check_count(results) > 0 -%}
+* [Warnings](#warnings): {{ test.warnings_for_check_count(results) }}
+{% for k in all_warnings.keys() -%}
+    {% if all_warnings[k]|length > 0 -%}
+        {% set anchor = k.lower()|replace(' ', '-') %}
+  * [{{ k|capitalize }}](#{{ anchor }}): {{ all_warnings[k]|length }}
+    {%- endif %}
+{%- endfor -%}
+{% endif %}
+{% if test.failures_for_check_count(results) > 0 %}
+* [Failures](#failures): {{ test.failures_for_check_count(results) }}
+{% for k in all_failures.keys() -%}
+    {% if all_failures[k]|length > 0 -%}
+        {% set anchor = k.lower()|replace(' ', '-') %}
+  * [{{ k|capitalize }}](#{{ anchor }}): {{ all_failures[k]|length }}
+    {%- endif %}
+{%- endfor -%}
+{% endif -%}
+{% endif %}
+
+
+{% if test.warnings_for_check_count(results) > 0 -%}
+## Warnings
+
+{% for type in all_warnings.keys()|sort -%}
+{% if all_warnings[type]|length > 0 %}
+#### {{ type|capitalize }} ####
+{% for at in all_warnings[type]| sort %}
+{% if not link -%}
+* {{ at -}}
+{%- else -%}
+* [{{ at }}]({{ link }}/{{ at }})
+{%- endif %}
+{%- endfor %}
+{% endif -%}
+{% endfor %}
+{% endif %}
+
+{% if test.failures_for_check_count(results) > 0 -%}
+## Failures
+
+{% for type in all_failures.keys()|sort -%}
+{% if all_failures[type]|length > 0 %}
+#### {{ type|capitalize }} ####
+{% for at in all_failures[type]| sort %}
+{% if not link -%}
+* {{ at -}}
+{%- else -%}
+* [{{ at -}}]({{ link }}/{{ at }})
+{%- endif %}
+{%- endfor %}
+{% endif -%}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Migrate IBM Cloud Databases fetcher for account specific list of databases and backups list.

## Why

Audits often request evidence to check whether databases are regularly being backed up.

## How

REST api calls will be made to the resource controller and IBM Cloud databases end points.

## Test

Local testing to be done to verify evidence being created.
#### fetch_databases.py
```
 time compliance --fetch --evidence local --notify stdout -C develop.json arboretum.ibm_cloud_databases.fetchers.fetch_databases

INFO: Using locker found in /var/folders/vv/9fgnxb454235bwsgw1wgl6840000gn/T/compliance...

Fetcher Primary Run

.
----------------------------------------------------------------------
Ran 1 test in 6.136s

OK

INFO: Committing changes to local locker in /var/folders/vv/9fgnxb454235bwsgw1wgl6840000gn/T/compliance...

real	0m6.577s
user	0m0.295s
sys	0m0.131s
```
The evidence file was generated and its contents verified
```
ls -la /var/folders/vv/9fgnxb454235bwsgw1wgl6840000gn/T/compliance/raw/icd/
total 120
drwxrwxr-x  4 Parthakumar.Roy@ibm.com  staff    128 Jan 14 16:34 .
drwxrwxr-x  3 Parthakumar.Roy@ibm.com  staff     96 Jan 14 16:19 ..
-rw-rw-r--  1 Parthakumar.Roy@ibm.com  staff  54030 Jan 14 16:34 databases_prod_1329217.json
-rw-rw-r--  1 Parthakumar.Roy@ibm.com  staff    164 Jan 14 16:34 index.json
```
#### fetch_backups.py
```
time compliance --fetch --evidence local --notify stdout -C develop.json arboretum.ibm_cloud_databases.fetchers.fetch_backups

INFO: Using locker found in /var/folders/vv/9fgnxb454235bwsgw1wgl6840000gn/T/compliance...

Fetcher Primary Run

.
----------------------------------------------------------------------
Ran 1 test in 19.527s

OK

INFO: Committing changes to local locker in /var/folders/vv/9fgnxb454235bwsgw1wgl6840000gn/T/compliance...

real	0m19.958s
user	0m0.455s
sys	0m0.145s
(arboretum3) Parthakumar.Roy@ibm.com:auditree-arboretum$ ls -al /var/folders/vv/9fgnxb454235bwsgw1wgl6840000gn/T/compliance/raw/icd/
total 80
drwxrwxr-x  5 Parthakumar.Roy@ibm.com  staff    160 Jan 15 09:58 .
drwxrwxr-x  3 Parthakumar.Roy@ibm.com  staff     96 Jan 14 16:19 ..
-rw-rw-r--  1 Parthakumar.Roy@ibm.com  staff      2 Jan 15 09:58 backups_prod_1329217.json
-rw-rw-r--  1 Parthakumar.Roy@ibm.com  staff  29971 Jan 15 09:54 databases_prod_1329217.json
-rw-rw-r--  1 Parthakumar.Roy@ibm.com  staff    327 Jan 15 09:58 index.json
```
**NOTE**: For the fetch_backups test to run to completion, certain entries in the database  evidence that were getting 404's had to be manually removed.

## Context

https://github.com/ComplianceAsCode/auditree-arboretum/issues/43