### PR TITLE
cluster resource fetcher for IBM Cloud

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [0.16.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.16.0)
+
+- [ADDED] IBM Cloud cluster resources fetcher added.
+
 # [0.15.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.15.0)
 
 - [ADDED] Github org permissions check added to `permissions`.

--- a/arboretum/__init__.py
+++ b/arboretum/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Arboretum - Checking your compliance & security posture, continuously."""
 
-__version__ = '0.15.0'
+__version__ = '0.16.0'

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -117,6 +117,6 @@ Checks coming soon...
 [ibm-cloud-api]: https://containers.cloud.ibm.com/
 [ibm-cloud-gen-api-console]: https://cloud.ibm.com/docs/account?topic=account-userapikey#create_user_key
 [fetch-ibm-cloud-cluster-resource]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
-[fetch-kube-cluster-resource]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/kubernetes/fetchers/fetch_cluster_resource.py
+[fetch-kube-cluster-resource]: https://github.com/ComplianceAsCode/auditree-arboretum/tree/main/arboretum/kubernetes#cluster-resource
 [ibm-cloud-download-config]: https://cloud.ibm.com/apidocs/kubernetes#getclusterconfig
 [ibm-cloud-roks-oauth]: https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_automation

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -62,6 +62,49 @@ to include the fetchers and checks from this library in your downstream project.
    from arboretum.ibm_cloud.fetchers.fetch_cluster_list import ClusterListFetcher
    ```
 
+### Cluster Resource
+
+* Class: [ClusterResourceFetcher][fetch-ibm-cloud-cluster-resource]
+* Purpose: Write the resources of IBM Cloud Kubernetes clusters to the evidence locker.
+* Behavior: Retrieve the resources of IBM Cloud Kubernetes clusters listed by [cluster list fetcher][fetch-cluster-list]. For IBM Cloud Kubernetes Service (IKS) clusters, the fetcher [downloads cluster config via IBM Cloud API][ibm-cloud-download-config] and extract the access token from the config. For IBM Cloud Red Hat Kubernetes Service (ROKS) clusters, the fetcher retrieves the access token using [the OAUTH server][ibm-cloud-roks-oauth] of the cluster. TTL is set to 1 day.
+
+* Configuration elements:
+  * `org.ibm_cloud.accounts`
+    * Required
+    * List of accounts (string)
+    * Each account is an arbitrary name describing the IBM Cloud account. It is used to match to the token provided in the
+      credentials file in order for the fetcher to retrieve content from IBM Cloud for that account.
+  * `org.ibm_cloud.cluster_resources.target_resource_types`
+    * Optional
+    * List of resource types as strings
+    * See the document of the [Kubernetes resource fetcher][fetch-kube-cluster-resource] for details.
+* Expected configuration:
+
+  ```json
+  {
+    "org": {
+      "ibm_cloud": {
+        "accounts": [
+          "myaccount1", "myaccount2"
+        ],
+        "cluster_resources": {
+          "target_resource_types": [
+            "secrets", "batch/v1/cronjobs", "apigroup.example.com/v1/mycustom"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+* Required credentials:
+  * `ibm_cloud` credentials with read/view permissions are needed for this fetcher to successfully retrieve the evidence.  See `Required credentials` of the [cluster list fetcher][fetch-cluster-list].
+* Import statement:
+
+   ```python
+   from arboretum.ibm_cloud.fetchers.fetch_cluster_resource import ClusterResourceFetcher
+   ```
+
 ## Checks
 
 Checks coming soon...
@@ -73,3 +116,7 @@ Checks coming soon...
 [fetch-cluster-list]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/ibm_cloud/fetchers/fetch_cluster_list.py
 [ibm-cloud-api]: https://containers.cloud.ibm.com/
 [ibm-cloud-gen-api-console]: https://cloud.ibm.com/docs/account?topic=account-userapikey#create_user_key
+[fetch-ibm-cloud-cluster-resource]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+[fetch-kube-cluster-resource]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/kubernetes/fetchers/fetch_cluster_resource.py
+[ibm-cloud-download-config]: https://cloud.ibm.com/apidocs/kubernetes#getclusterconfig
+[ibm-cloud-roks-oauth]: https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_automation

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -77,7 +77,24 @@ to include the fetchers and checks from this library in your downstream project.
   * `org.ibm_cloud.cluster_resources.types`
     * Optional
     * List of resource types as strings
-    * See the document of the [Kubernetes resource fetcher][fetch-kube-cluster-resource] for details.
+      * NOTE: For core group API resources, the resource name must be in
+      _plural form_ (e.g., `secrets`).
+      * NOTE: For other named group resources including custom API
+        resources, the resource name must be in the following format:
+        `APIGROUP/VERSION/NAME`. You can compose this by first executing
+        `kubectl api-resources` and `kubectl api-versions` and then combining
+        the results into your resource name.  Using `cronjobs` as an example:
+
+        ```sh
+        $ kubectl api-resources -o name | fgrep cronjobs
+        cronjobs.batch
+        $ kubectl api-versions | grep batch
+        batch/v1
+        batch/v1beta1
+        ```
+
+        For this example `batch/v1` is the more stable version so we use that
+        to compose `APIGROUP/VERSION/NAME` resource name as `batch/v1/cronjobs`.
 * Expected configuration:
 
   ```json

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -74,7 +74,7 @@ to include the fetchers and checks from this library in your downstream project.
     * List of accounts (string)
     * Each account is an arbitrary name describing the IBM Cloud account. It is used to match to the token provided in the
       credentials file in order for the fetcher to retrieve content from IBM Cloud for that account.
-  * `org.ibm_cloud.cluster_resources.target_resource_types`
+  * `org.ibm_cloud.cluster_resources.types`
     * Optional
     * List of resource types as strings
     * See the document of the [Kubernetes resource fetcher][fetch-kube-cluster-resource] for details.

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -65,8 +65,8 @@ to include the fetchers and checks from this library in your downstream project.
 ### Cluster Resource
 
 * Class: [ICClusterResourceFetcher][fetch-ibm-cloud-cluster-resource]
-* Purpose: Write the resources of IBM Cloud Kubernetes clusters to the evidence locker.
-* Behavior: Retrieve tokens for IBM Cloud Kubernetes clusters listed by [IBM Cloud cluster list fetcher][fetch-cluster-list] using `api_key` in `~/.credentials`, and then retrieve specified `target_resource_types` of the clusters using the tokens. This fetcher uses one `api_key` per account which owns multiple clusters, while [Kubernetes resource fetcher][fetch-kube-cluster-resource] uses one `token` per cluster. TTL is set to 1 day.
+* Purpose: Write the resources of **managed** Kubernetes clusters to the evidence locker. NOTE: Do not use this fetcher for stand-alone clusters. For Kubernetes stand-alone clusters, use the [Kubernetes cluster resource fetcher][fetch-kube-cluster-resource].
+* Behavior: Retrieve tokens for IBM Cloud Kubernetes clusters listed by [IBM Cloud cluster list fetcher][fetch-cluster-list] using `api_key` in `~/.credentials`, and then retrieve specified resources  using the tokens. TTL is set to 1 day.
 
 * Configuration elements:
   * `org.ibm_cloud.accounts`

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -98,7 +98,22 @@ to include the fetchers and checks from this library in your downstream project.
   ```
 
 * Required credentials:
-  * `ibm_cloud` credentials with read/view permissions are needed for this fetcher to successfully retrieve the evidence.  See `Required credentials` of the [cluster list fetcher][fetch-cluster-list].
+  * `ibm_cloud` credentials with read/view permissions are needed for this fetcher to successfully retrieve the evidence.
+    * `XXX_api_key`: API key string for account `XXX`.
+    * Example credential file entry:
+
+      ```ini
+      [ibm_cloud]
+      acct_a_api_key=your-ibm-cloud-api-key-for-acct-a
+      acct_b_api_key=your-ibm-cloud-api-key-for-acct-b
+      ```
+
+    * NOTE: API keys can be generated using the [IBM Cloud CLI][ic-api-key-create] or [IBM Cloud Console][ibm-cloud-gen-api-console]. Example to create an API key with IBM Cloud CLI is:
+
+      ```sh
+      ibmcloud iam api-key-create your-iks-api-key-for-acct-x
+      ```
+
 * Import statement:
 
    ```python

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -64,7 +64,7 @@ to include the fetchers and checks from this library in your downstream project.
 
 ### Cluster Resource
 
-* Class: [ClusterResourceFetcher][fetch-ibm-cloud-cluster-resource]
+* Class: [ICClusterResourceFetcher][fetch-ibm-cloud-cluster-resource]
 * Purpose: Write the resources of IBM Cloud Kubernetes clusters to the evidence locker.
 * Behavior: Retrieve the resources of IBM Cloud Kubernetes clusters listed by [cluster list fetcher][fetch-cluster-list]. For IBM Cloud Kubernetes Service (IKS) clusters, the fetcher [downloads cluster config via IBM Cloud API][ibm-cloud-download-config] and extract the access token from the config. For IBM Cloud Red Hat Kubernetes Service (ROKS) clusters, the fetcher retrieves the access token using [the OAUTH server][ibm-cloud-roks-oauth] of the cluster. TTL is set to 1 day.
 
@@ -102,7 +102,7 @@ to include the fetchers and checks from this library in your downstream project.
 * Import statement:
 
    ```python
-   from arboretum.ibm_cloud.fetchers.fetch_cluster_resource import ClusterResourceFetcher
+   from arboretum.ibm_cloud.fetchers.fetch_cluster_resource import ICClusterResourceFetcher
    ```
 
 ## Checks

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -66,7 +66,7 @@ to include the fetchers and checks from this library in your downstream project.
 
 * Class: [ICClusterResourceFetcher][fetch-ibm-cloud-cluster-resource]
 * Purpose: Write the resources of IBM Cloud Kubernetes clusters to the evidence locker.
-* Behavior: Retrieve tokens for IBM Cloud Kubernetes clusters listed by [IBM Cloud cluster list fetcher][fetch-cluster-list] using `api_key` in `~/.credentials`, and then retrieve specified `target_resource_types` of the clusters using the tokens. TTL is set to 1 day.
+* Behavior: Retrieve tokens for IBM Cloud Kubernetes clusters listed by [IBM Cloud cluster list fetcher][fetch-cluster-list] using `api_key` in `~/.credentials`, and then retrieve specified `target_resource_types` of the clusters using the tokens. This fetcher uses one `api_key` per account which owns multiple clusters, while [Kubernetes resource fetcher][fetch-kube-cluster-resource] uses one `token` per cluster. TTL is set to 1 day.
 
 * Configuration elements:
   * `org.ibm_cloud.accounts`

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -105,7 +105,7 @@ to include the fetchers and checks from this library in your downstream project.
           "myaccount1", "myaccount2"
         ],
         "cluster_resources": {
-          "target_resource_types": [
+          "types": [
             "secrets", "batch/v1/cronjobs", "apigroup.example.com/v1/mycustom"
           ]
         }

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -65,8 +65,12 @@ to include the fetchers and checks from this library in your downstream project.
 ### Cluster Resource
 
 * Class: [ICClusterResourceFetcher][fetch-ibm-cloud-cluster-resource]
-* Purpose: Write the resources of **managed** Kubernetes clusters to the evidence locker. NOTE: Do not use this fetcher for stand-alone clusters. For Kubernetes stand-alone clusters, use the [Kubernetes cluster resource fetcher][fetch-kube-cluster-resource].
-* Behavior: Retrieve tokens for IBM Cloud Kubernetes clusters listed by [IBM Cloud cluster list fetcher][fetch-cluster-list] using `api_key` in `~/.credentials`, and then retrieve specified resources  using the tokens. TTL is set to 1 day.
+* Purpose: Write the resources of **managed** Kubernetes clusters to the evidence locker.
+* Behavior: Retrieve managed Kubernetes cluster resource data based on clusters gathered by the [IBM Cloud cluster list fetcher][fetch-cluster-list].  TTL is set to 1 day.
+* NOTE: 
+   * Do not use this fetcher for stand-alone clusters. For Kubernetes stand-alone clusters, use the [Kubernetes cluster resource fetcher][fetch-kube-cluster-resource].
+   * This fetcher is dependent on evidence gathered by the [IBM Cloud cluster list fetcher][fetch-cluster-list], 
+ i.e. importing the IBM Cloud cluster list fetcher is a prerequisite for the IKS cluster resource fetcher to work.
 
 * Configuration elements:
   * `org.ibm_cloud.accounts`

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -66,7 +66,7 @@ to include the fetchers and checks from this library in your downstream project.
 
 * Class: [ICClusterResourceFetcher][fetch-ibm-cloud-cluster-resource]
 * Purpose: Write the resources of IBM Cloud Kubernetes clusters to the evidence locker.
-* Behavior: Retrieve the resources of IBM Cloud Kubernetes clusters listed by [cluster list fetcher][fetch-cluster-list]. For IBM Cloud Kubernetes Service (IKS) clusters, the fetcher [downloads cluster config via IBM Cloud API][ibm-cloud-download-config] and extract the access token from the config. For IBM Cloud Red Hat Kubernetes Service (ROKS) clusters, the fetcher retrieves the access token using [the OAUTH server][ibm-cloud-roks-oauth] of the cluster. TTL is set to 1 day.
+* Behavior: Retrieve tokens for IBM Cloud Kubernetes clusters listed by [IBM Cloud cluster list fetcher][fetch-cluster-list] using `api_key` in `~/.credentials`, and then retrieve specified `target_resource_types` of the clusters using the tokens. TTL is set to 1 day.
 
 * Configuration elements:
   * `org.ibm_cloud.accounts`
@@ -118,5 +118,3 @@ Checks coming soon...
 [ibm-cloud-gen-api-console]: https://cloud.ibm.com/docs/account?topic=account-userapikey#create_user_key
 [fetch-ibm-cloud-cluster-resource]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
 [fetch-kube-cluster-resource]: https://github.com/ComplianceAsCode/auditree-arboretum/tree/main/arboretum/kubernetes#cluster-resource
-[ibm-cloud-download-config]: https://cloud.ibm.com/apidocs/kubernetes#getclusterconfig
-[ibm-cloud-roks-oauth]: https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_automation

--- a/arboretum/ibm_cloud/README.md
+++ b/arboretum/ibm_cloud/README.md
@@ -71,7 +71,7 @@ to include the fetchers and checks from this library in your downstream project.
 * Configuration elements:
   * `org.ibm_cloud.accounts`
     * Required
-    * List of accounts (string)
+    * List of accounts as strings
     * Each account is an arbitrary name describing the IBM Cloud account. It is used to match to the token provided in the
       credentials file in order for the fetcher to retrieve content from IBM Cloud for that account.
   * `org.ibm_cloud.cluster_resources.types`

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -122,9 +122,7 @@ class ICClusterResourceFetcher(ComplianceFetcher):
         cluster_list = cluster_list_evidence.content_as_json
         resources = {}
         for account in cluster_list:
-            api_key = getattr(
-                self.config.creds['ibm_cloud'], f'{account}_api_key'
-            )
+            api_key = self.config.creds.get('ibm_cloud', f'{account}_api_key')
             headers = {'Accept': 'application/json'}
             self.session('https://containers.cloud.ibm.com', **headers)
             access_token, refresh_token = get_tokens(api_key)

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -119,7 +119,7 @@ class ICClusterResourceFetcher(ComplianceFetcher):
         cluster_list_evidence = get_evidence_dependency(
             'raw/ibm_cloud/cluster_list.json', self.locker
         )
-        cluster_list = json.loads(cluster_list_evidence.content)
+        cluster_list = cluster_list_evidence.content_as_json
         resources = {}
         for account in cluster_list:
             api_key = getattr(

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -134,11 +134,11 @@ class ICClusterResourceFetcher(ComplianceFetcher):
                 if cluster['type'] == 'kubernetes':
                     cluster_token, ca_cert = self._get_iks_credentials(
                         cluster_config
-                        )
+                    )
                 elif cluster['type'] == 'openshift':
                     cluster_token, ca_cert = self._get_roks_credentials(
                         cluster, api_key
-                        )
+                    )
                 self.session(cluster['serverURL'], **headers)
                 cluster['resources'] = get_cluster_resources(
                     self.session(),

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -116,7 +116,7 @@ class ICClusterResourceFetcher(ComplianceFetcher):
                 kubeconfig = yaml.safe_load(cluster_config.read(name))
                 usr = kubeconfig['users'][0]['user']
                 cluster_token = usr['auth-provider']['config']['id-token']
-            if p.name.endswith('.pem'):
+            if p.suffix == '.pem':
                 t = pathlib.Path(self.tempdir.name)
                 cluster_config.extract(name, path=t)
                 ca_cert_filepath = t / name

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -101,10 +101,7 @@ class ICClusterResourceFetcher(ComplianceFetcher):
             allow_redirects=False
         )
         location = resp.headers['Location']
-        keyword = 'access_token='
-        start = location.find(keyword)
-        end = location.find('&', start)
-        cluster_token = location[start + len(keyword):end]
+        cluster_token = location.split('access_token=', 1)[1].split('&', 1)[0]
         s.headers.update = ({'X-CSRF-Token': None})
 
         return cluster_token, None

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -70,8 +70,8 @@ class ICClusterResourceFetcher(ComplianceFetcher):
             p = pathlib.Path(name)
             if p.name.startswith('kube-config'):
                 kubeconfig = yaml.safe_load(cluster_config.read(name))
-                cluster_token = kubeconfig['users'][0]['user'][
-                    'auth-provider']['config']['id-token']
+                usr = kubeconfig['users'][0]['user']
+                cluster_token = usr['auth-provider']['config']['id-token']
             if p.name.endswith('.pem'):
                 cluster_config.extract(name, path=self.tempdir.name)
                 ca_cert_filepath = os.path.join(self.tempdir.name, name)

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -117,9 +117,10 @@ class ICClusterResourceFetcher(ComplianceFetcher):
                 usr = kubeconfig['users'][0]['user']
                 cluster_token = usr['auth-provider']['config']['id-token']
             if p.name.endswith('.pem'):
-                t = pathlib.Path(self.tempdir.name)
-                cluster_config.extract(name, path=t)
-                ca_cert_filepath = t / name
+                cluster_config.extract(name, path=self.tempdir.name)
+                ca_cert_filepath = str(
+                    pathlib.PurePath(self.tempdir.name, name)
+                )
         return cluster_token, ca_cert_filepath
 
     def _get_roks_credentials(self, cluster, api_key):

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -103,7 +103,7 @@ class ICClusterResourceFetcher(ComplianceFetcher):
         location = resp.headers['Location']
         cluster_token = location.split('access_token=', 1)[1].split('&', 1)[0]
 
-        return cluster_token, None
+        return cluster_token
 
     @store_raw_evidence('ibm_cloud/cluster_resources.json')
     def fetch_cluster_resource(self):
@@ -135,9 +135,10 @@ class ICClusterResourceFetcher(ComplianceFetcher):
                         cluster_config
                     )
                 elif cluster['type'] == 'openshift':
-                    cluster_token, ca_cert = self._get_roks_credentials(
+                    cluster_token = self._get_roks_credentials(
                         cluster, api_key
                     )
+                    ca_cert = None
                 self.session(cluster['serverURL'], **headers)
                 cluster['resources'] = get_cluster_resources(
                     self.session(),

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -72,17 +72,6 @@ class ClusterResourceFetcher(ComplianceFetcher):
                     name, path=self.tempdir.name
                 )
                 ca_cert_filepath = os.path.join(self.tempdir.name, name)
-        if cluster_token is None:
-            raise RuntimeError(
-                'Failed to extract token from the config'
-                f'file for cluster "{cluster["name"]}".'
-            )
-        if ca_cert_filepath is None:
-            raise RuntimeError(
-                'Failed to extract CA certificate file '
-                '(*.pem) from the config file '
-                f'for cluster "{cluster["name"]}".'
-            )
         return cluster_token, ca_cert_filepath
 
     def _get_roks_credentials(self, cluster, api_key):
@@ -107,11 +96,6 @@ class ClusterResourceFetcher(ComplianceFetcher):
         keyword = 'access_token='
         start = location.find(keyword)
         end = location.find('&', start)
-        if start < 0 or end < 0:
-            raise RuntimeError(
-                'Failed to extract access token '
-                f'for cluster "{cluster["name"]}"'
-            )
         cluster_token = location[start + len(keyword):end]
         s.headers.update = ({'X-CSRF-Token': None})
 
@@ -155,11 +139,6 @@ class ClusterResourceFetcher(ComplianceFetcher):
                 elif cluster['type'] == 'openshift':
                     cluster_token, ca_cert = self._get_roks_credentials(
                         cluster, api_key)
-                else:
-                    raise RuntimeError(
-                        f'Cluster "{cluster["name"]}" is '
-                        f'unsupported cluster type: {cluster["type"]}'
-                    )
                 self.session(cluster['serverURL'], **headers)
                 cluster['resources'] = get_cluster_resources(
                     self.session(),

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -16,7 +16,6 @@
 
 import io
 import json
-import os
 import pathlib
 import tempfile
 import zipfile
@@ -73,8 +72,9 @@ class ICClusterResourceFetcher(ComplianceFetcher):
                 usr = kubeconfig['users'][0]['user']
                 cluster_token = usr['auth-provider']['config']['id-token']
             if p.name.endswith('.pem'):
-                cluster_config.extract(name, path=self.tempdir.name)
-                ca_cert_filepath = os.path.join(self.tempdir.name, name)
+                t = pathlib.Path(self.tempdir.name)
+                cluster_config.extract(name, path=t)
+                ca_cert_filepath = t / name
         return cluster_token, ca_cert_filepath
 
     def _get_roks_credentials(self, cluster, api_key):

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Feching cluster resource from IBM Cloud."""
+"""IBM Cloud cluster resource fetcher."""
 
 import io
 import json

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -59,6 +59,11 @@ class ICClusterResourceFetcher(ComplianceFetcher):
         cls.tempdir.cleanup()
 
     def _get_iks_credentials(self, cluster, cluster_configs):
+        """Get credentials for an IKS cluster.
+
+        This function implements the procedure described in
+        https://cloud.ibm.com/apidocs/kubernetes#getclusterconfig
+        """
         for name in cluster_configs[cluster['name']].namelist():
             p = pathlib.Path(name)
             if p.name.startswith('kube-config'):
@@ -75,6 +80,11 @@ class ICClusterResourceFetcher(ComplianceFetcher):
         return cluster_token, ca_cert_filepath
 
     def _get_roks_credentials(self, cluster, api_key):
+        """Get credentials for a ROKS cluster.
+
+        This function implements the procedure described in
+        https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_automation
+        """
         s = self.session(cluster['serverURL'])
         oauth_path = '/.well-known/oauth-authorization-server'
         resp = s.get(oauth_path)

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -1,0 +1,172 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2021 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Feching cluster resource from IBM Cloud."""
+
+import io
+import json
+import os
+import pathlib
+import tempfile
+import zipfile
+
+from arboretum.common.iam_ibm_utils import get_tokens
+from arboretum.common.kube_constants import RESOURCE_TYPES_DEFAULT
+from arboretum.common.kube_utils import get_cluster_resources
+
+from compliance.evidence import DAY, RawEvidence, evidences, store_raw_evidence
+from compliance.fetch import ComplianceFetcher
+
+import yaml
+
+
+class ClusterResourceFetcher(ComplianceFetcher):
+    """Fetch resources of IBM Cloud Kubernetes clusters."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialize the fetcher object with configuration settings."""
+        cls.config.add_evidences(
+            [
+                RawEvidence(
+                    'cluster_resources.json',
+                    'ibm_cloud',
+                    DAY,
+                    'IBM Cloud Kubernetes cluster resources'
+                )
+            ]
+        )
+        cls.resource_types = cls.config.get(
+            'org.ibm_cloud.cluster_resources.types', RESOURCE_TYPES_DEFAULT
+        )
+        cls.tempdir = tempfile.TemporaryDirectory()
+        return cls
+
+    @classmethod
+    def tearDownClass(cls):
+        """Cleanup class."""
+        cls.tempdir.cleanup()
+
+    def _get_iks_credentials(self, cluster, cluster_configs):
+        for name in cluster_configs[cluster['name']].namelist():
+            p = pathlib.Path(name)
+            if p.name.startswith('kube-config'):
+                kubeconfig = yaml.safe_load(
+                    cluster_configs[cluster['name']].read(name)
+                )
+                cluster_token = kubeconfig['users'][0]['user'][
+                    'auth-provider']['config']['id-token']
+            if p.name.endswith('.pem'):
+                cluster_configs[cluster['name']].extract(
+                    name, path=self.tempdir.name
+                )
+                ca_cert_filepath = os.path.join(self.tempdir.name, name)
+        if cluster_token is None:
+            raise RuntimeError(
+                'Failed to extract token from the config'
+                f'file for cluster "{cluster["name"]}".'
+            )
+        if ca_cert_filepath is None:
+            raise RuntimeError(
+                'Failed to extract CA certificate file '
+                '(*.pem) from the config file '
+                f'for cluster "{cluster["name"]}".'
+            )
+        return cluster_token, ca_cert_filepath
+
+    def _get_roks_credentials(self, cluster, api_key):
+        s = self.session(cluster['serverURL'])
+        oauth_path = '/.well-known/oauth-authorization-server'
+        resp = s.get(oauth_path)
+        resp.raise_for_status()
+        token_endpoint = resp.json()['token_endpoint']
+        oauth_server = token_endpoint.split('/')[2]
+        s = self.session(f'https://{oauth_server}')
+        token_path = (
+            '/oauth/authorize?client_id='
+            'openshift-challenging-client&response_type=token'
+        )
+        resp = s.get(
+            token_path,
+            auth=('apikey', api_key),
+            headers={'X-CSRF-Token': 'a'},
+            allow_redirects=False
+        )
+        location = resp.headers['Location']
+        keyword = 'access_token='
+        start = location.find(keyword)
+        end = location.find('&', start)
+        if start < 0 or end < 0:
+            raise RuntimeError(
+                'Failed to extract access token '
+                f'for cluster "{cluster["name"]}"'
+            )
+        cluster_token = location[start + len(keyword):end]
+        s.headers.update = ({'X-CSRF-Token': None})
+
+        return cluster_token, None
+
+    @store_raw_evidence('ibm_cloud/cluster_resources.json')
+    def fetch_cluster_resource(self):
+        """Fetch cluster resources."""
+        with evidences(self.locker, 'raw/ibm_cloud/cluster_list.json') as ev:
+            cluster_list = json.loads(ev.content)
+        resources = {}
+        for account in cluster_list:
+            api_key = getattr(
+                self.config.creds['ibm_cloud'], f'{account}_api_key'
+            )
+            headers = {'Accept': 'application/json'}
+            self.session('https://containers.cloud.ibm.com', **headers)
+            access_token, refresh_token = get_tokens(api_key)
+            self.session().headers.update(
+                {
+                    'Authorization': 'Bearer '
+                    f'{access_token}',
+                    'X-Auth-Refresh-Token': refresh_token
+                }
+            )
+            cluster_config = {}
+            for cluster in cluster_list[account]:
+                resp = self.session().get(
+                    '/global/v1/clusters/'
+                    f'{cluster["id"]}/config'
+                )
+                resp.raise_for_status()
+                cluster_config[cluster['name']] = zipfile.ZipFile(
+                    io.BytesIO(resp.content)
+                )
+            resources[account] = []
+            for cluster in cluster_list[account]:
+                if cluster['type'] == 'kubernetes':
+                    cluster_token, ca_cert = self._get_iks_credentials(
+                        cluster, cluster_config)
+                elif cluster['type'] == 'openshift':
+                    cluster_token, ca_cert = self._get_roks_credentials(
+                        cluster, api_key)
+                else:
+                    raise RuntimeError(
+                        f'Cluster "{cluster["name"]}" is '
+                        f'unsupported cluster type: {cluster["type"]}'
+                    )
+                self.session(cluster['serverURL'], **headers)
+                cluster['resources'] = get_cluster_resources(
+                    self.session(),
+                    cluster_token,
+                    self.resource_types,
+                    ca_cert
+                )
+                resources[account].append(cluster)
+
+        return json.dumps(resources)

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -25,7 +25,9 @@ from arboretum.common.iam_ibm_utils import get_tokens
 from arboretum.common.kube_constants import RESOURCE_TYPES_DEFAULT
 from arboretum.common.kube_utils import get_cluster_resources
 
-from compliance.evidence import DAY, RawEvidence, evidences, store_raw_evidence
+from compliance.evidence import (
+    DAY, RawEvidence, get_evidence_dependency, store_raw_evidence
+)
 from compliance.fetch import ComplianceFetcher
 
 import yaml
@@ -114,8 +116,10 @@ class ICClusterResourceFetcher(ComplianceFetcher):
     @store_raw_evidence('ibm_cloud/cluster_resources.json')
     def fetch_cluster_resource(self):
         """Fetch cluster resources."""
-        with evidences(self.locker, 'raw/ibm_cloud/cluster_list.json') as ev:
-            cluster_list = json.loads(ev.content)
+        cluster_list_evidence = get_evidence_dependency(
+            'raw/ibm_cloud/cluster_list.json', self.locker
+        )
+        cluster_list = json.loads(cluster_list_evidence.content)
         resources = {}
         for account in cluster_list:
             api_key = getattr(

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -136,10 +136,12 @@ class ICClusterResourceFetcher(ComplianceFetcher):
                 cluster_config = zipfile.ZipFile(io.BytesIO(resp.content))
                 if cluster['type'] == 'kubernetes':
                     cluster_token, ca_cert = self._get_iks_credentials(
-                        cluster_config)
+                        cluster_config
+                        )
                 elif cluster['type'] == 'openshift':
                     cluster_token, ca_cert = self._get_roks_credentials(
-                        cluster, api_key)
+                        cluster, api_key
+                        )
                 self.session(cluster['serverURL'], **headers)
                 cluster['resources'] = get_cluster_resources(
                     self.session(),

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -111,7 +111,7 @@ class ICClusterResourceFetcher(ComplianceFetcher):
         https://cloud.ibm.com/apidocs/kubernetes#getclusterconfig
         """
         for name in cluster_config.namelist():
-            p = pathlib.Path(name)
+            p = pathlib.PurePath(name)
             if p.name.startswith('kube-config'):
                 kubeconfig = yaml.safe_load(cluster_config.read(name))
                 usr = kubeconfig['users'][0]['user']

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -138,8 +138,7 @@ class ICClusterResourceFetcher(ComplianceFetcher):
             cluster_config = {}
             for cluster in cluster_list[account]:
                 resp = self.session().get(
-                    '/global/v1/clusters/'
-                    f'{cluster["id"]}/config'
+                    f'/global/v1/clusters/{cluster["id"]}/config'
                 )
                 resp.raise_for_status()
                 cluster_config[cluster['name']] = zipfile.ZipFile(

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -31,7 +31,7 @@ from compliance.fetch import ComplianceFetcher
 import yaml
 
 
-class ClusterResourceFetcher(ComplianceFetcher):
+class ICClusterResourceFetcher(ComplianceFetcher):
     """Fetch resources of IBM Cloud Kubernetes clusters."""
 
     @classmethod

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -130,8 +130,8 @@ class ICClusterResourceFetcher(ComplianceFetcher):
             resources[account] = []
             for cluster in cluster_list[account]:
                 self.session('https://containers.cloud.ibm.com', **headers)
-                resp = self.session(
-                ).get(f'/global/v1/clusters/{cluster["id"]}/config')
+                config_url = f'/global/v1/clusters/{cluster["id"]}/config'
+                resp = self.session().get(config_url)
                 resp.raise_for_status()
                 cluster_config = zipfile.ZipFile(io.BytesIO(resp.content))
                 if cluster['type'] == 'kubernetes':

--- a/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
+++ b/arboretum/ibm_cloud/fetchers/fetch_cluster_resource.py
@@ -102,7 +102,6 @@ class ICClusterResourceFetcher(ComplianceFetcher):
         )
         location = resp.headers['Location']
         cluster_token = location.split('access_token=', 1)[1].split('&', 1)[0]
-        s.headers.update = ({'X-CSRF-Token': None})
 
         return cluster_token, None
 

--- a/arboretum/kubernetes/README.md
+++ b/arboretum/kubernetes/README.md
@@ -75,7 +75,6 @@ list of clusters.  TTL is set to 1 day.
   }
    ```
 
-
 * Required credentials:
   * A token of a Kubernetes service account is required.
     * `<cluster label>_token`: a token string for the cluster label value from

--- a/arboretum/kubernetes/README.md
+++ b/arboretum/kubernetes/README.md
@@ -21,7 +21,9 @@ to include the fetchers and checks from this library in your downstream project.
 * Class: [ClusterResourceFetcher][fetch-cluster-resource]
 * Purpose: Write the resources of **stand-alone** Kubernetes clusters to the
 evidence locker.  **NOTE:** Do not use this fetcher for managed clusters.
-Instead use the [IBM Cloud cluster list fetcher][ibm-cloud-cluster-list-fetcher].
+For IBM Cloud clusters, use the
+[IBM Cloud cluster list fetcher][ibm-cloud-cluster-list-fetcher] and the
+[IBM Cloud cluster resource fetcher][ibm-cloud-cluster-resource-fetcher].
 * Behavior: Retrieve stand-alone Kubernetes cluster resource data for the provided
 list of clusters.  TTL is set to 1 day.
 * Configuration elements:
@@ -120,4 +122,5 @@ Checks coming soon...
 [usage]: https://github.com/ComplianceAsCode/auditree-arboretum#usage
 [fetch-cluster-resource]: https://github.com/ComplianceAsCode/auditree-arboretum/blob/main/arboretum/kubernetes/fetchers/fetch_cluster_resource.py
 [ibm-cloud-cluster-list-fetcher]: https://github.com/ComplianceAsCode/auditree-arboretum/tree/main/arboretum/ibm_cloud#cluster-list
+[ibm-cloud-cluster-resource-fetcher]: https://github.com/ComplianceAsCode/auditree-arboretum/tree/main/arboretum/ibm_cloud#cluster-resource
 [kube-rbac-docs]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/

--- a/arboretum/kubernetes/README.md
+++ b/arboretum/kubernetes/README.md
@@ -73,6 +73,7 @@ list of clusters.  TTL is set to 1 day.
   }
    ```
 
+
 * Required credentials:
   * A token of a Kubernetes service account is required.
     * `<cluster label>_token`: a token string for the cluster label value from

--- a/devel.json
+++ b/devel.json
@@ -89,7 +89,7 @@
       "accounts": ["my_ic_account_one", "my_ic_account_two"],
       "cluster_resources": {
         "types": ["pods"]
-        }
+      }
     },
     "kubernetes": {
       "cluster_resources": {

--- a/devel.json
+++ b/devel.json
@@ -86,7 +86,10 @@
       ]
     },
     "ibm_cloud": {
-      "accounts": ["my_ic_account_one", "my_ic_account_two"]
+      "accounts": ["my_ic_account_one", "my_ic_account_two"],
+      "cluster_resources": {
+        "types": ["pods"]
+        }
     },
     "kubernetes": {
       "cluster_resources": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ packages = find:
 install_requires =
     auditree-framework>=1.2.3
     auditree-harvest>=1.0.0
+    PyYAML
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 install_requires =
     auditree-framework>=1.2.3
     auditree-harvest>=1.0.0
-    PyYAML
+    pyyaml<5.4
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add functionality of fetching resources from IBM Cloud Kubernetes clusters.

## Why

Kubernetes resources (e.g., output of `kubectl get pod`) can be used as evidence. For example, spec of Pod, custom resource of an operator, and ConfigMap shows whether applications (pod) and kubernetes infrastructure (operator) run with correct (expected) configuration. Managed clusters have their own mechanism to manage multiple clusters, and therefore a specific fetcher for each managed cluster is required. This PR contains a fetcher for IBM Cloud clusters.

## How

- add Kubernetes resource fetcher for IBM Cloud clusters to `ibm_cloud` category
- add a package `PyYAML` to `setup.cfg` to parse configuration of IBM Cloud clusters
- modify `arboretum/kubernetes/README.md` to add link to the cluster resource fetcher section in `arboretum/ibm_cloud/README.md`


## Test

- fetching resources from IBM Cloud clusters (both IBM Cloud Kubernetes Service and Red Hat OpenShift Kubernetes Service)

## Context

- issue: #9 
- related PR: #32 - this PR has been spun off from #32
