### PR TITLE
Add GH Org Integrity Teams fetcher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [0.12.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.12.0)
+
+- [ADDED] Github org integrity teams fetcher functionality added to Github org integrity permissions fetcher.
+
 # [0.11.1](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.11.1)
 
 - [FIXED] Renamed RepoMetadataEvidence `filtered_content` to `relevant_content`.
@@ -5,7 +9,7 @@
 # [0.11.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.11.0)
 
 - [ADDED] Github org integrity fetcher added to `permissions`.
-- [ADDED] Github org integrity forks fetcher functionality added Github org integrity fetcher.
+- [ADDED] Github org integrity forks fetcher functionality added to Github org integrity permissions fetcher.
 - [CHANGED] Github org integrity collaborators fetcher functionality added to Github org integrity permissions fetcher.
 
 # [0.10.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.10.0)

--- a/arboretum/__init__.py
+++ b/arboretum/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Arboretum - Checking your compliance & security posture, continuously."""
 
-__version__ = '0.11.1'
+__version__ = '0.12.0'

--- a/arboretum/permissions/README.md
+++ b/arboretum/permissions/README.md
@@ -19,8 +19,8 @@ how to include the fetchers and checks from this library in your downstream proj
 ### Organization Integrity Permissions
 
 * Class: [GithubOrgPermissionFetcher][fetch-org-permissions]
-* Purpose: Writes the details of collaborators and repository forks in Github organizations to the evidence locker. This fetcher class is only meant for use with Github or Github Enterprise organizations.
-* Behavior: For each Github organization specified, Github collaborator and Github fork evidence files per collaborator type (affiliation) are stored in the locker containing details for the specified repositories in the organization. The default is to retrieve all collaborators and all forks by affiliation from all repositories in each specified Github organization.  TTL is set to 1 day.
+* Purpose: Writes the details of teams, collaborators and repository forks in Github organizations to the evidence locker. This fetcher class is only meant for use with Github or Github Enterprise organizations.
+* Behavior: For each Github organization specified Github fork, Github team, and Github collaborator evidence files are stored in the locker containing details for the specified repositories in the organization. For Github collaborators the evidence stored can be limited to specified affiliation. The default is to retrieve all teams, forks and collaborators by affiliation from all repositories in each specified Github organization. TTL is set to 1 day.
 * Configuration elements:
   * `org.permissions.org_integrity.orgs`
      * Required

--- a/arboretum/permissions/fetchers/github/fetch_org_permissions.py
+++ b/arboretum/permissions/fetchers/github/fetch_org_permissions.py
@@ -50,3 +50,33 @@ class GithubOrgPermissionsFetcher(collabs.GithubOrgCollaboratorsFetcher):
                             f'repos/{org}/{repo}/forks'
                         )
                     evidence.set_content(json.dumps(forks))
+
+    def fetch_repo_teams(self):
+        """Fetch Github repository teams."""
+        for config in self.config.get('org.permissions.org_integrity.orgs'):
+            host, org = config['url'].rsplit('/', 1)
+            url_hash = collabs.get_sha256_hash([config['url']], 10)
+            path = ['permissions', f'gh_teams_{url_hash}.json']
+            description = f'Repo access for GH teams in the {org} GH org'
+            self.config.add_evidences(
+                [
+                    collabs.RawEvidence(
+                        path[1], path[0], collabs.DAY, description
+                    )
+                ]
+            )
+            with collabs.raw_evidence(self.locker, '/'.join(path)) as evidence:
+                if evidence:
+                    if host not in self.gh_pool:
+                        self.gh_pool[host] = collabs.Github(base_url=host)
+                    if not config.get('repos'):
+                        repos = self.gh_pool[host].paginate_api(
+                            f'orgs/{org}/repos'
+                        )
+                        config['repos'] = [repo['name'] for repo in repos]
+                    teams = {}
+                    for repo in config['repos']:
+                        teams[repo] = self.gh_pool[host].paginate_api(
+                            f'repos/{org}/{repo}/teams'
+                        )
+                    evidence.set_content(json.dumps(teams))


### PR DESCRIPTION
- [ x ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add a fetcher method that will gather teams list for each repo of a Github organization.

## Why

This fetcher is needed to control access to source code.

## How

- fetch_org_permissions.py
- README.md

## Test

N/A

## Context

Closes #52