### PR TITLE
Fix filtered_content property/attribute name collision

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [0.11.1](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.11.1)
+
+- [FIXED] Renamed RepoMetadataEvidence `filtered_content` to `relevant_content`.
+
 # [0.11.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.11.0)
 
 - [ADDED] Github org integrity fetcher added to `permissions`.

--- a/arboretum/__init__.py
+++ b/arboretum/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Arboretum - Checking your compliance & security posture, continuously."""
 
-__version__ = '0.11.0'
+__version__ = '0.11.1'

--- a/arboretum/auditree/checks/test_locker_repo_integrity.py
+++ b/arboretum/auditree/checks/test_locker_repo_integrity.py
@@ -109,8 +109,8 @@ class LockerRepoIntegrityCheck(ComplianceCheck):
                         )
                     difference = ''.join(
                         context_diff(
-                            prev.filtered_content.splitlines(keepends=True),
-                            current.filtered_content.splitlines(keepends=True),
+                            prev.relevant_content.splitlines(keepends=True),
+                            current.relevant_content.splitlines(keepends=True),
                             path,
                             path,
                             previous_dt.strftime('%b %d, %Y'),

--- a/arboretum/auditree/evidences/repo_metadata.py
+++ b/arboretum/auditree/evidences/repo_metadata.py
@@ -39,18 +39,18 @@ class RepoMetadataEvidence(RawEvidence):
             return self._size
 
     @property
-    def filtered_content(self):
+    def relevant_content(self):
         """Provide evidence content minus the ignored fields as JSON."""
         if self.content:
-            if not hasattr(self, '_filtered_content'):
+            if not hasattr(self, '_relevant_content'):
                 metadata = json.loads(self.content)
                 for field in IGNORE_REPO_METADATA[self.name[:2]]:
                     try:
                         metadata.pop(field)
                     except KeyError:
                         pass
-                self._filtered_content = str(format_json(metadata))
-            return self._filtered_content
+                self._relevant_content = str(format_json(metadata))
+            return self._relevant_content
 
     def _get_gh_repo_size(self):
         return json.loads(self.content)['size']

--- a/test/test_evidences/test_repo_metadata.py
+++ b/test/test_evidences/test_repo_metadata.py
@@ -27,7 +27,7 @@ class RepoMetadataEvidenceTest(unittest.TestCase):
         """Ensure properties requiring content return None when no content."""
         evidence = RepoMetadataEvidence('gh_foo.json', 'bar')
         self.assertIsNone(evidence.repo_size)
-        self.assertIsNone(evidence.filtered_content)
+        self.assertIsNone(evidence.relevant_content)
 
     def test_gl_not_implemented(self):
         """Ensure NotImplementedError raised for Gitlab."""
@@ -55,10 +55,10 @@ class RepoMetadataEvidenceTest(unittest.TestCase):
         )
         self.assertEqual(evidence.repo_size, 12345)
 
-    def test_filtered_content(self):
+    def test_relevant_content(self):
         """Ensure all IGNORED_REPO_METADATA fields are parsed out."""
         evidence = RepoMetadataEvidence('gh_foo.json', 'bar')
         evidence.set_content(
             open('./test/fixtures/gh_repo_metadata.json').read()
         )
-        self.assertEqual(json.loads(evidence.filtered_content), {'foo': 'bar'})
+        self.assertEqual(json.loads(evidence.relevant_content), {'foo': 'bar'})


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix filtered_content property/attribute name collision.

## Why

So that the repo metadata fetcher can fetch evidence again.

## How

Renamed RepoMetadataEvidence `filtered_content` to `relevant_content` 

## Test

- Fetcher now runs locally
- Check produces results using the new property `relevant_content`.

## Context

Closes #56
