### PR TITLE
Fix permissions org direct collab check to error when no evidence found

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.30.0
+    rev: v0.31.0
     hooks:
     -   id: yapf
         args: [--in-place, --parallel, --recursive, --style, .yapf-config]
         files: "^(arboretum|test)"
         stages: [commit]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
     -   id: flake8
         args: [

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [0.12.1](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.12.1)
+
+- [FIXED] Org repo direct collaborators check now ERRORS when no direct collaborator evidence is found.
+
 # [0.12.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.12.0)
 
 - [ADDED] Github org integrity teams fetcher functionality added to Github org integrity permissions fetcher.

--- a/arboretum/__init__.py
+++ b/arboretum/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Arboretum - Checking your compliance & security posture, continuously."""
 
-__version__ = '0.12.0'
+__version__ = '0.12.1'

--- a/arboretum/permissions/README.md
+++ b/arboretum/permissions/README.md
@@ -101,7 +101,8 @@ how to include the fetchers and checks from this library in your downstream proj
 * Behavior: Collaborators are checked for every repository.
 A failure is generated when direct collaborators are found in a repository. This check can be optionally
 configured to accept exceptions, a warning instead of a failure is generated for those exceptions when
-direct collaborators matching the exceptions are found.
+direct collaborators matching the exceptions are found.  If no `"direct"` collaborator type evidence is
+found then the check will ERROR.
 * Evidence depended upon:
     * `direct` collaborators found in organization repositories.
       * `raw/permissions/<gh|gl|bb>_direct_collaborators_<org_url_hash>.json`
@@ -118,7 +119,7 @@ direct collaborators matching the exceptions are found.
            * List of dictionaries:
              * `user`
                 * Required
-                * Github, Gitlab or Bitbucket user id (string). 
+                * Github, Gitlab or Bitbucket user id (string).
                 * Use to define the user to be treated as an exception.
                 * NOTE: Only Github is currently supported by this check. Gitlab and Bitbucket support coming soon...
              * `repos`
@@ -126,6 +127,11 @@ direct collaborators matching the exceptions are found.
                 * List of strings in the form of `["repo_a", "repo_b"]`.
                 * Defaults to all repositories in the organization.
                 * Use to limit the user exception to specific repositories in the organization.
+        * `collaborator_types`
+           * Optional
+           * List of strings in the form of `["all", "direct", "outside"]`.
+           * Valid list element values are `"all"`, `"direct"`, `"outside"`.
+           * List must include `"direct"` in order for check to look for direct collaborator evidence.
 * Example configuration:
 
   ```json

--- a/arboretum/permissions/checks/test_org_collaborators.py
+++ b/arboretum/permissions/checks/test_org_collaborators.py
@@ -17,6 +17,7 @@
 from compliance.check import ComplianceCheck
 from compliance.evidence import DAY, ReportEvidence, evidences
 from compliance.utils.data_parse import get_sha256_hash
+from compliance.utils.exceptions import EvidenceNotFoundError
 
 
 class OrgCollaboratorsCheck(ComplianceCheck):
@@ -66,6 +67,10 @@ class OrgCollaboratorsCheck(ComplianceCheck):
             path = f'raw/permissions/{filename}'
             evidence_paths[org_name] = path
             exceptions[org_name] = org.get('exceptions', [])
+        if not evidence_paths:
+            raise EvidenceNotFoundError(
+                'No direct collaborator evidence found!'
+            )
         with evidences(self, evidence_paths) as raws:
             self._generate_results(raws, exceptions)
 

--- a/controls.json
+++ b/controls.json
@@ -1,37 +1,10 @@
 {
-  "arboretum.auditree.checks.test_abandoned_evidence.AbandonedEvidenceCheck": {
-    "auditree_evidence": {
-      "auditree_control": ["arboretum.auditree"]
-    }
-  },
-  "arboretum.auditree.checks.test_compliance_config.ComplianceConfigCheck": {
-    "auditree_evidence": {
-      "auditree_control": ["arboretum.auditree"]
-    }
-  },
-  "arboretum.auditree.checks.test_python_packages.PythonPackageCheck": {
-    "auditree_evidence": {
-      "auditree_control": ["arboretum.auditree"]
-    }
-  },
-  "arboretum.auditree.checks.test_locker_repo_integrity.LockerRepoIntegrityCheck": {
-    "auditree_evidence": {
-      "auditree_control": ["arboretum.auditree"]
-    }
-  },
-  "arboretum.auditree.checks.test_locker_commit_integrity.LockerCommitIntegrityCheck": {
-    "auditree_evidence": {
-      "auditree_control": ["arboretum.auditree"]
-    }
-  },
-  "arboretum.auditree.checks.test_repo_branch_commits.RepoBranchNewCommitsCheck": {
-    "auditree_evidence": {
-      "auditree_control": ["arboretum.auditree"]
-    }
-  },
-  "arboretum.auditree.checks.test_filepath_commits.FilepathNewCommitsCheck": {
-    "auditree_evidence": {
-      "auditree_control": ["arboretum.auditree"]
-    }
-  }
+  "arboretum.auditree.checks.test_abandoned_evidence.AbandonedEvidenceCheck": ["arboretum.auditree"],
+  "arboretum.auditree.checks.test_compliance_config.ComplianceConfigCheck": ["arboretum.auditree"],
+  "arboretum.auditree.checks.test_python_packages.PythonPackageCheck": ["arboretum.auditree"],
+  "arboretum.auditree.checks.test_locker_repo_integrity.LockerRepoIntegrityCheck": ["arboretum.auditree"],
+  "arboretum.auditree.checks.test_locker_commit_integrity.LockerCommitIntegrityCheck": ["arboretum.auditree"],
+  "arboretum.auditree.checks.test_repo_branch_commits.RepoBranchNewCommitsCheck": ["arboretum.auditree"],
+  "arboretum.auditree.checks.test_filepath_commits.FilepathNewCommitsCheck": ["arboretum.auditree"],
+  "arboretum.permissions.checks.test_org_collaborators.OrgCollaboratorsCheck": ["arboretum.permissions"]
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix permissions org direct collab check to error when no evidence found.

## Why

When no direct collaborator evidence is found by the check, it should error rather than pass with "no issues found" (current behavior).

## How

Add logic to raise an EvidenceNotFoundError exception when no evidence is found by the check.

## Test

- Current functionality preserved when evidence is found
- Check errors when no evidence is found

## Context

Fixes #61 
