### PR TITLE
Bump pyyaml version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [0.17.1](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.17.1)
+
+- [CHANGED] Bump pyyaml version.
+
 # [0.17.0](https://github.com/ComplianceAsCode/auditree-arboretum/releases/tag/v0.17.0)
 
 - [ADDED] Azure fetchers.

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 install_requires =
     auditree-framework>=1.2.3
     auditree-harvest>=1.0.0
-    pyyaml<5.4
+    pyyaml>=5.4.1
     defusedxml>=0.7.1
     parameterized>=0.8.1
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)

## What

As explained in #68, pyyaml is limited to <5.4 version and this version is currently vulnerable. As far we can tell, the use of this library should carry on working without issues.

Closes #68

## Why

Current version is vulnerable.

## How

Allow the installation of any newer `pyyaml` version.

